### PR TITLE
Add monitoring anomaly detectors and weekly quality reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ Cada artículo incluye un payload de "why ranked" con contribuciones por feature
 - `python scripts/evaluate_ranking.py` → NDCG@5, Precision@5, MRR sobre un dev set.
 - `python scripts/reranker_distribution.py` → distribución de fuentes/temas antes vs. después del reranker.
 - `python scripts/enrichment_sanity.py` → sanity check de enriquecimiento (lenguaje, sentimiento, tópicos, entidades).
+- `python scripts/weekly_quality_report.py tests/data/monitoring/outage_replay.json` → genera reporte semanal en formato común.
+- `python scripts/replay_outage.py tests/data/monitoring/outage_replay.json` → replay de outage histórico con alertas canario.
+- Ver especificación del formato en `docs/common_output_format.md`.
 
 ### 🛠️ Facilidad de Uso
 - **Instalación Simple**: Una línea de comando

--- a/docs/common_output_format.md
+++ b/docs/common_output_format.md
@@ -1,0 +1,44 @@
+# Monitoring Common Output Format (monitoring.v1)
+
+All monitoring entrypoints emit JSON payloads following this schema:
+
+```json
+{
+  "version": "monitoring.v1",
+  "status": "ok" | "info" | "warning" | "critical",
+  "window": {
+    "start": "ISO-8601 UTC timestamp",
+    "end": "ISO-8601 UTC timestamp"
+  },
+  "generated_at": "ISO-8601 UTC timestamp",
+  "metrics": [
+    {"name": "metric.name", "value": 0.1, "unit": "optional", "labels": {"k": "v"}}
+  ],
+  "anomalies": [
+    {
+      "detector": "source_outage",
+      "severity": "critical",
+      "message": "Human readable summary",
+      "labels": {"source_id": "nature"},
+      "observations": {"ratio": 0.1}
+    }
+  ],
+  "alerts": [
+    {
+      "title": "Canary failure for nature",
+      "severity": "critical",
+      "targets": ["pager", "slack://#news-alerts"],
+      "runbook_url": "https://runbooks.noticiencias/collector-outage",
+      "labels": {"source_id": "nature"},
+      "annotations": {"error": "..."}
+    }
+  ],
+  "metadata": {
+    "suppressed_sources": ["nature"]
+  }
+}
+```
+
+The `status` field is derived automatically from the highest severity among
+anomalies and alerts. All timestamps must be in UTC and ISO-8601 with timezone
+offset.

--- a/scripts/replay_outage.py
+++ b/scripts/replay_outage.py
@@ -1,0 +1,32 @@
+"""Replay a historical outage dataset and emit alerts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC_DIR = ROOT / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+from monitoring import default_quality_report_generator
+from monitoring.io import load_monitoring_dataset
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("input", type=Path, help="Path to outage replay JSON payload")
+    args = parser.parse_args()
+
+    payload = json.loads(Path(args.input).read_text(encoding="utf-8"))
+    dataset = load_monitoring_dataset(payload)
+    generator = default_quality_report_generator()
+    report = generator.generate(dataset)
+    print(json.dumps(report.to_dict(), indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entrypoint
+    main()

--- a/scripts/weekly_quality_report.py
+++ b/scripts/weekly_quality_report.py
@@ -1,0 +1,41 @@
+"""Generate weekly quality monitoring report in the common output format."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC_DIR = ROOT / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+from monitoring import QualityReportGenerator, default_quality_report_generator
+from monitoring.io import load_monitoring_dataset
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("input", type=Path, help="Path to weekly stats JSON file")
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Optional path to write the monitoring payload (JSON)",
+    )
+    args = parser.parse_args()
+
+    payload = json.loads(Path(args.input).read_text(encoding="utf-8"))
+    dataset = load_monitoring_dataset(payload)
+
+    generator: QualityReportGenerator = default_quality_report_generator()
+    report = generator.generate(dataset)
+    output = json.dumps(report.to_dict(), indent=2, sort_keys=True)
+    if args.output:
+        Path(args.output).write_text(output, encoding="utf-8")
+    print(output)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entrypoint
+    main()

--- a/src/monitoring/__init__.py
+++ b/src/monitoring/__init__.py
@@ -1,0 +1,57 @@
+"""Monitoring utilities for Noticiencias."""
+
+from .common import (
+    Alert,
+    Anomaly,
+    Metric,
+    MonitoringPayload,
+    Severity,
+    COMMON_PAYLOAD_VERSION,
+)
+from .detectors import (
+    SourceBaseline,
+    SourceWindowStats,
+    SourceOutageDetector,
+    SourceOutageDetectorConfig,
+    SchemaDriftDetector,
+    SchemaExpectation,
+    ContentShiftDetector,
+    ContentShiftThresholds,
+)
+from .canary import (
+    CanaryCheck,
+    CanaryResult,
+    CanaryRunner,
+    AutoSuppressionManager,
+    SuppressionDecision,
+)
+from .reporting import (
+    QualityReportGenerator,
+    MonitoringDataset,
+    default_quality_report_generator,
+)
+
+__all__ = [
+    "Alert",
+    "Anomaly",
+    "Metric",
+    "MonitoringPayload",
+    "Severity",
+    "COMMON_PAYLOAD_VERSION",
+    "SourceBaseline",
+    "SourceWindowStats",
+    "SourceOutageDetector",
+    "SourceOutageDetectorConfig",
+    "SchemaDriftDetector",
+    "SchemaExpectation",
+    "ContentShiftDetector",
+    "ContentShiftThresholds",
+    "CanaryCheck",
+    "CanaryResult",
+    "CanaryRunner",
+    "AutoSuppressionManager",
+    "SuppressionDecision",
+    "QualityReportGenerator",
+    "MonitoringDataset",
+    "default_quality_report_generator",
+]

--- a/src/monitoring/canary.py
+++ b/src/monitoring/canary.py
@@ -1,0 +1,151 @@
+"""Canary checks and auto-suppression logic for sources."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import List, Mapping, Optional, Sequence
+
+from zoneinfo import ZoneInfo
+
+from .common import Alert, Anomaly, Severity
+from .detectors import SourceWindowStats
+
+UTC = ZoneInfo("UTC")
+
+
+@dataclass(slots=True)
+class CanaryCheck:
+    """Represents an automated health probe for a source."""
+
+    source_id: str
+    max_latency_ms: float
+    max_idle_hours: float
+    min_articles: int = 1
+
+
+@dataclass(slots=True)
+class CanaryResult:
+    """Outcome from executing a canary check."""
+
+    source_id: str
+    latency_ms: float
+    articles_found: int
+    last_seen_hours: float
+    error: Optional[str] = None
+
+    @property
+    def healthy(self) -> bool:
+        return self.error is None
+
+
+@dataclass(slots=True)
+class SuppressionDecision:
+    """Decision to auto-suppress a source."""
+
+    source_id: str
+    reason: str
+    severity: Severity
+
+
+class CanaryRunner:
+    """Aggregates canary results from window statistics."""
+
+    def __init__(self, checks: Sequence[CanaryCheck]) -> None:
+        self._checks = {check.source_id: check for check in checks}
+
+    def execute(self, stats: Sequence[SourceWindowStats]) -> List[CanaryResult]:
+        results: List[CanaryResult] = []
+        now = datetime.now(tz=UTC)
+        for window in stats:
+            check = self._checks.get(window.source_id)
+            if not check:
+                continue
+            last_seen_hours = 1e9
+            if window.last_article_at:
+                last_seen_hours = (now - window.last_article_at).total_seconds() / 3600
+            error: Optional[str] = None
+            if last_seen_hours > check.max_idle_hours:
+                error = (
+                    f"last article seen {last_seen_hours:.1f}h ago (limit {check.max_idle_hours}h)"
+                )
+            elif window.articles_found < check.min_articles:
+                error = (
+                    f"only {window.articles_found} article(s) fetched (<{check.min_articles})"
+                )
+            results.append(
+                CanaryResult(
+                    source_id=window.source_id,
+                    latency_ms=check.max_latency_ms,
+                    articles_found=window.articles_found,
+                    last_seen_hours=last_seen_hours,
+                    error=error,
+                )
+            )
+        return results
+
+
+class AutoSuppressionManager:
+    """Automatically suppresses sources with repeated critical failures."""
+
+    def __init__(
+        self,
+        failure_threshold: int = 2,
+        idle_hours_threshold: float = 48.0,
+    ) -> None:
+        self._failure_threshold = failure_threshold
+        self._idle_hours_threshold = idle_hours_threshold
+
+    def evaluate(
+        self,
+        stats: Sequence[SourceWindowStats],
+        anomalies: Sequence[Anomaly],
+    ) -> List[SuppressionDecision]:
+        decisions: List[SuppressionDecision] = []
+        by_source: Mapping[str, List[Anomaly]] = {}
+        for anomaly in anomalies:
+            source_id = anomaly.labels.get("source_id") if anomaly.labels else None
+            if not source_id:
+                continue
+            if source_id not in by_source:
+                by_source[source_id] = []
+            by_source[source_id].append(anomaly)
+        for window in stats:
+            source_anomalies = by_source.get(window.source_id, [])
+            critical_events = [a for a in source_anomalies if a.severity == Severity.CRITICAL]
+            last_seen_hours = 0.0
+            if window.last_article_at:
+                last_seen_hours = (datetime.now(tz=UTC) - window.last_article_at).total_seconds() / 3600
+            if (
+                len(critical_events) >= self._failure_threshold
+                or last_seen_hours >= self._idle_hours_threshold
+                or window.consecutive_failures >= self._failure_threshold
+            ):
+                decisions.append(
+                    SuppressionDecision(
+                        source_id=window.source_id,
+                        reason="Repeated critical anomalies",
+                        severity=Severity.CRITICAL,
+                    )
+                )
+        return decisions
+
+
+def build_canary_alerts(results: Sequence[CanaryResult]) -> List[Alert]:
+    alerts: List[Alert] = []
+    for result in results:
+        if result.error:
+            alerts.append(
+                Alert(
+                    title=f"Canary failure for {result.source_id}",
+                    severity=Severity.CRITICAL,
+                    runbook_url="https://runbooks.noticiencias/collector-outage",
+                    targets=["pager", "slack://#news-alerts"],
+                    labels={"source_id": result.source_id},
+                    annotations={
+                        "error": result.error,
+                        "last_seen_hours": round(result.last_seen_hours, 2),
+                    },
+                )
+            )
+    return alerts

--- a/src/monitoring/common.py
+++ b/src/monitoring/common.py
@@ -1,0 +1,180 @@
+"""Common monitoring data structures and helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+from typing import Any, Dict, List, Mapping, MutableMapping, Optional
+
+from zoneinfo import ZoneInfo
+
+UTC = ZoneInfo("UTC")
+
+
+class Severity(str, Enum):
+    """Normalized severity levels for monitoring signals."""
+
+    OK = "ok"
+    INFO = "info"
+    WARNING = "warning"
+    CRITICAL = "critical"
+
+
+COMMON_PAYLOAD_VERSION = "monitoring.v1"
+
+
+@dataclass(slots=True)
+class Metric:
+    """Scalar metric in the common monitoring output format."""
+
+    name: str
+    value: float
+    unit: Optional[str] = None
+    labels: Mapping[str, str] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {
+            "name": self.name,
+            "value": self.value,
+        }
+        if self.unit:
+            payload["unit"] = self.unit
+        if self.labels:
+            payload["labels"] = dict(self.labels)
+        return payload
+
+
+@dataclass(slots=True)
+class Anomaly:
+    """An anomaly detected by the monitoring system."""
+
+    detector: str
+    severity: Severity
+    message: str
+    labels: Mapping[str, str] = field(default_factory=dict)
+    observations: Mapping[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {
+            "detector": self.detector,
+            "severity": self.severity.value,
+            "message": self.message,
+        }
+        if self.labels:
+            payload["labels"] = dict(self.labels)
+        if self.observations:
+            payload["observations"] = dict(self.observations)
+        return payload
+
+
+@dataclass(slots=True)
+class Alert:
+    """Actionable alert derived from anomalies."""
+
+    title: str
+    severity: Severity
+    runbook_url: Optional[str]
+    targets: List[str]
+    labels: Mapping[str, str] = field(default_factory=dict)
+    annotations: Mapping[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {
+            "title": self.title,
+            "severity": self.severity.value,
+            "targets": list(self.targets),
+        }
+        if self.runbook_url:
+            payload["runbook_url"] = self.runbook_url
+        if self.labels:
+            payload["labels"] = dict(self.labels)
+        if self.annotations:
+            payload["annotations"] = dict(self.annotations)
+        return payload
+
+
+@dataclass(slots=True)
+class MonitoringPayload:
+    """Canonical monitoring payload used across monitoring surfaces."""
+
+    status: Severity
+    window_start: datetime
+    window_end: datetime
+    generated_at: datetime = field(default_factory=lambda: datetime.now(tz=UTC))
+    metrics: List[Metric] = field(default_factory=list)
+    anomalies: List[Anomaly] = field(default_factory=list)
+    alerts: List[Alert] = field(default_factory=list)
+    metadata: MutableMapping[str, Any] = field(default_factory=dict)
+    version: str = COMMON_PAYLOAD_VERSION
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "version": self.version,
+            "status": self.status.value,
+            "window": {
+                "start": self.window_start.isoformat(),
+                "end": self.window_end.isoformat(),
+            },
+            "generated_at": self.generated_at.isoformat(),
+            "metrics": [metric.to_dict() for metric in self.metrics],
+            "anomalies": [anomaly.to_dict() for anomaly in self.anomalies],
+            "alerts": [alert.to_dict() for alert in self.alerts],
+            "metadata": dict(self.metadata),
+        }
+
+    @classmethod
+    def from_components(
+        cls,
+        window_start: datetime,
+        window_end: datetime,
+        metrics: Optional[List[Metric]] = None,
+        anomalies: Optional[List[Anomaly]] = None,
+        alerts: Optional[List[Alert]] = None,
+        metadata: Optional[Mapping[str, Any]] = None,
+    ) -> "MonitoringPayload":
+        """Build a payload inferring the status from anomalies/alerts."""
+
+        highest = Severity.OK
+        for candidate in (alerts or []):
+            if candidate.severity == Severity.CRITICAL:
+                highest = Severity.CRITICAL
+                break
+            if candidate.severity == Severity.WARNING and highest not in {
+                Severity.CRITICAL,
+            }:
+                highest = Severity.WARNING
+        else:
+            for anomaly in (anomalies or []):
+                if anomaly.severity == Severity.CRITICAL:
+                    highest = Severity.CRITICAL
+                    break
+                if anomaly.severity == Severity.WARNING and highest not in {
+                    Severity.CRITICAL,
+                }:
+                    highest = Severity.WARNING
+                if (
+                    anomaly.severity == Severity.INFO
+                    and highest not in {Severity.CRITICAL, Severity.WARNING}
+                ):
+                    highest = Severity.INFO
+        payload = cls(
+            status=highest,
+            window_start=window_start,
+            window_end=window_end,
+        )
+        if metrics:
+            payload.metrics.extend(metrics)
+        if anomalies:
+            payload.anomalies.extend(anomalies)
+        if alerts:
+            payload.alerts.extend(alerts)
+        if metadata:
+            payload.metadata.update(dict(metadata))
+        return payload
+
+
+def serialize_payload(payload: MonitoringPayload) -> Dict[str, Any]:
+    """Return a dict representation of a payload (alias for compatibility)."""
+
+    return payload.to_dict()

--- a/src/monitoring/detectors.py
+++ b/src/monitoring/detectors.py
@@ -1,0 +1,397 @@
+"""Anomaly detectors for source health, schema drift, and content shifts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from math import log2
+from typing import Dict, List, Mapping, MutableMapping, Optional, Sequence
+
+from zoneinfo import ZoneInfo
+
+from .common import Anomaly, Metric, Severity
+
+UTC = ZoneInfo("UTC")
+
+
+@dataclass(slots=True)
+class SourceBaseline:
+    """Baseline expectations for a news source."""
+
+    expected_articles_per_window: float
+    max_gap_hours: float
+    language_distribution: Mapping[str, float]
+    topic_distribution: Mapping[str, float]
+
+
+@dataclass(slots=True)
+class SourceWindowStats:
+    """Aggregated stats for a source within a monitoring window."""
+
+    source_id: str
+    window_start: datetime
+    window_end: datetime
+    articles_found: int
+    expected_count: int
+    last_article_at: Optional[datetime]
+    consecutive_failures: int
+    schema_violations: int
+    languages: Mapping[str, int] = field(default_factory=dict)
+    topics: Mapping[str, int] = field(default_factory=dict)
+
+    def language_distribution(self) -> Mapping[str, float]:
+        total = sum(self.languages.values())
+        if total == 0:
+            return {}
+        return {lang: count / total for lang, count in self.languages.items()}
+
+    def topic_distribution(self) -> Mapping[str, float]:
+        total = sum(self.topics.values())
+        if total == 0:
+            return {}
+        return {topic: count / total for topic, count in self.topics.items()}
+
+
+@dataclass(slots=True)
+class SourceOutageDetectorConfig:
+    warn_ratio: float = 0.5
+    alert_ratio: float = 0.2
+    consecutive_failure_threshold: int = 3
+
+
+class SourceOutageDetector:
+    """Detects outages or severe degradation for ingestion sources."""
+
+    def __init__(
+        self,
+        config: Optional[SourceOutageDetectorConfig] = None,
+        now: Optional[datetime] = None,
+    ) -> None:
+        self._config = config or SourceOutageDetectorConfig()
+        self._now = now or datetime.now(tz=UTC)
+
+    def evaluate(
+        self,
+        stats: Sequence[SourceWindowStats],
+        baselines: Mapping[str, SourceBaseline],
+    ) -> Dict[str, List]:
+        anomalies: List[Anomaly] = []
+        metrics: List[Metric] = []
+        for window in stats:
+            baseline = baselines.get(window.source_id)
+            if not baseline:
+                continue
+            ratio = (
+                window.articles_found / baseline.expected_articles_per_window
+                if baseline.expected_articles_per_window > 0
+                else 1.0
+            )
+            metrics.append(
+                Metric(
+                    name="source.ingestion_ratio",
+                    value=ratio,
+                    labels={
+                        "source_id": window.source_id,
+                    },
+                )
+            )
+            severity: Optional[Severity] = None
+            message: Optional[str] = None
+            if window.consecutive_failures >= self._config.consecutive_failure_threshold:
+                severity = Severity.CRITICAL
+                message = (
+                    f"Source {window.source_id} has {window.consecutive_failures} consecutive fetch failures"
+                )
+            elif ratio <= self._config.alert_ratio:
+                severity = Severity.CRITICAL
+                message = (
+                    f"Source {window.source_id} delivered {window.articles_found} articles vs. "
+                    f"expected {baseline.expected_articles_per_window:.1f}"
+                )
+            elif ratio <= self._config.warn_ratio:
+                severity = Severity.WARNING
+                message = (
+                    f"Source {window.source_id} volume dropped to {ratio:.2f} of baseline"
+                )
+            last_seen_gap = None
+            if window.last_article_at:
+                last_seen_gap = (self._now - window.last_article_at).total_seconds() / 3600
+                metrics.append(
+                    Metric(
+                        name="source.last_seen_gap_hours",
+                        value=last_seen_gap,
+                        labels={"source_id": window.source_id},
+                    )
+                )
+                if last_seen_gap > baseline.max_gap_hours:
+                    gap_message = (
+                        f"Source {window.source_id} idle for {last_seen_gap:.1f}h"
+                        f" (threshold {baseline.max_gap_hours}h)"
+                    )
+                    if severity is None:
+                        severity = Severity.CRITICAL
+                        message = gap_message
+                    else:
+                        message = f"{message}; {gap_message}" if message else gap_message
+            if message and severity:
+                anomalies.append(
+                    Anomaly(
+                        detector="source_outage",
+                        severity=severity,
+                        message=message,
+                        labels={
+                            "source_id": window.source_id,
+                        },
+                        observations={
+                            "ratio": round(ratio, 3),
+                            "articles_found": window.articles_found,
+                            "expected": baseline.expected_articles_per_window,
+                            "consecutive_failures": window.consecutive_failures,
+                            "last_seen_gap_hours": round(last_seen_gap or 0.0, 2),
+                        },
+                    )
+                )
+        return {"metrics": metrics, "anomalies": anomalies}
+
+
+@dataclass(slots=True)
+class SchemaExpectation:
+    """Expected schema definition for normalized articles."""
+
+    required_fields: Mapping[str, type]
+    optional_fields: Mapping[str, type] = field(default_factory=dict)
+    max_missing_ratio: float = 0.05
+    max_type_mismatch_ratio: float = 0.02
+
+
+class SchemaDriftDetector:
+    """Detects schema drift based on article payload samples."""
+
+    def __init__(self, expectation: SchemaExpectation) -> None:
+        self._expectation = expectation
+
+    def evaluate(
+        self, samples: Sequence[Mapping[str, object]]
+    ) -> Dict[str, List]:
+        if not samples:
+            return {"metrics": [], "anomalies": []}
+        total = len(samples)
+        missing_counts: MutableMapping[str, int] = {key: 0 for key in self._expectation.required_fields}
+        type_mismatch_counts: MutableMapping[str, int] = {
+            key: 0 for key in self._expectation.required_fields
+        }
+        optional_mismatch: MutableMapping[str, int] = {
+            key: 0 for key in self._expectation.optional_fields
+        }
+        for sample in samples:
+            for field_name, field_type in self._expectation.required_fields.items():
+                if field_name not in sample or sample[field_name] is None:
+                    missing_counts[field_name] += 1
+                    continue
+                if not isinstance(sample[field_name], field_type):
+                    type_mismatch_counts[field_name] += 1
+            for field_name, field_type in self._expectation.optional_fields.items():
+                if field_name in sample and sample[field_name] is not None:
+                    if not isinstance(sample[field_name], field_type):
+                        optional_mismatch[field_name] += 1
+        anomalies: List[Anomaly] = []
+        metrics: List[Metric] = []
+        for field_name, count in missing_counts.items():
+            ratio = count / total
+            metrics.append(
+                Metric(
+                    name="schema.missing_ratio",
+                    value=ratio,
+                    labels={"field": field_name},
+                )
+            )
+            if ratio > self._expectation.max_missing_ratio:
+                anomalies.append(
+                    Anomaly(
+                        detector="schema_drift",
+                        severity=Severity.CRITICAL,
+                        message=f"Field '{field_name}' missing in {ratio:.1%} of samples",
+                        labels={"field": field_name},
+                        observations={"missing_ratio": round(ratio, 3)},
+                    )
+                )
+        for field_name, count in type_mismatch_counts.items():
+            ratio = count / total
+            metrics.append(
+                Metric(
+                    name="schema.type_mismatch_ratio",
+                    value=ratio,
+                    labels={"field": field_name},
+                )
+            )
+            if ratio > self._expectation.max_type_mismatch_ratio:
+                anomalies.append(
+                    Anomaly(
+                        detector="schema_drift",
+                        severity=Severity.WARNING,
+                        message=f"Field '{field_name}' has {ratio:.1%} type mismatches",
+                        labels={"field": field_name},
+                        observations={"type_mismatch_ratio": round(ratio, 3)},
+                    )
+                )
+        for field_name, count in optional_mismatch.items():
+            ratio = count / total
+            metrics.append(
+                Metric(
+                    name="schema.optional_type_mismatch_ratio",
+                    value=ratio,
+                    labels={"field": field_name},
+                )
+            )
+        return {"metrics": metrics, "anomalies": anomalies}
+
+
+@dataclass(slots=True)
+class ContentShiftThresholds:
+    language_divergence_alert: float = 0.25
+    topic_divergence_alert: float = 0.35
+    language_divergence_warn: float = 0.15
+    topic_divergence_warn: float = 0.25
+
+
+class ContentShiftDetector:
+    """Detects shifts in language/topic distributions."""
+
+    def __init__(
+        self,
+        thresholds: Optional[ContentShiftThresholds] = None,
+    ) -> None:
+        self._thresholds = thresholds or ContentShiftThresholds()
+
+    def evaluate(
+        self,
+        stats: Sequence[SourceWindowStats],
+        baselines: Mapping[str, SourceBaseline],
+    ) -> Dict[str, List]:
+        if not stats:
+            return {"metrics": [], "anomalies": []}
+        aggregated_languages: MutableMapping[str, int] = {}
+        aggregated_topics: MutableMapping[str, int] = {}
+        baseline_language: MutableMapping[str, float] = {}
+        baseline_topic: MutableMapping[str, float] = {}
+        for window in stats:
+            for lang, count in window.languages.items():
+                aggregated_languages[lang] = aggregated_languages.get(lang, 0) + count
+            for topic, count in window.topics.items():
+                aggregated_topics[topic] = aggregated_topics.get(topic, 0) + count
+            baseline = baselines.get(window.source_id)
+            if baseline:
+                for lang, share in baseline.language_distribution.items():
+                    baseline_language[lang] = baseline_language.get(lang, 0.0) + share
+                for topic, share in baseline.topic_distribution.items():
+                    baseline_topic[topic] = baseline_topic.get(topic, 0.0) + share
+        aggregated_language_dist = _normalize_counts(aggregated_languages)
+        aggregated_topic_dist = _normalize_counts(aggregated_topics)
+        baseline_language_dist = _normalize_shares(baseline_language)
+        baseline_topic_dist = _normalize_shares(baseline_topic)
+        language_divergence = _jensen_shannon_divergence(
+            aggregated_language_dist, baseline_language_dist
+        )
+        topic_divergence = _jensen_shannon_divergence(
+            aggregated_topic_dist, baseline_topic_dist
+        )
+        metrics = [
+            Metric(name="content.language_jsd", value=language_divergence),
+            Metric(name="content.topic_jsd", value=topic_divergence),
+        ]
+        anomalies: List[Anomaly] = []
+        if language_divergence >= self._thresholds.language_divergence_alert:
+            anomalies.append(
+                Anomaly(
+                    detector="content_shift",
+                    severity=Severity.CRITICAL,
+                    message=f"Language mix diverged (JSD={language_divergence:.2f})",
+                    observations={
+                        "language_divergence": round(language_divergence, 3),
+                        "observed": aggregated_language_dist,
+                        "baseline": baseline_language_dist,
+                    },
+                )
+            )
+        elif language_divergence >= self._thresholds.language_divergence_warn:
+            anomalies.append(
+                Anomaly(
+                    detector="content_shift",
+                    severity=Severity.WARNING,
+                    message=f"Language mix drift detected (JSD={language_divergence:.2f})",
+                    observations={
+                        "language_divergence": round(language_divergence, 3),
+                        "observed": aggregated_language_dist,
+                        "baseline": baseline_language_dist,
+                    },
+                )
+            )
+        if topic_divergence >= self._thresholds.topic_divergence_alert:
+            anomalies.append(
+                Anomaly(
+                    detector="content_shift",
+                    severity=Severity.CRITICAL,
+                    message=f"Topic mix diverged (JSD={topic_divergence:.2f})",
+                    observations={
+                        "topic_divergence": round(topic_divergence, 3),
+                        "observed": aggregated_topic_dist,
+                        "baseline": baseline_topic_dist,
+                    },
+                )
+            )
+        elif topic_divergence >= self._thresholds.topic_divergence_warn:
+            anomalies.append(
+                Anomaly(
+                    detector="content_shift",
+                    severity=Severity.WARNING,
+                    message=f"Topic mix drift detected (JSD={topic_divergence:.2f})",
+                    observations={
+                        "topic_divergence": round(topic_divergence, 3),
+                        "observed": aggregated_topic_dist,
+                        "baseline": baseline_topic_dist,
+                    },
+                )
+            )
+        return {"metrics": metrics, "anomalies": anomalies}
+
+
+def _normalize_counts(counts: Mapping[str, int]) -> Mapping[str, float]:
+    total = sum(counts.values())
+    if total == 0:
+        return {}
+    return {key: value / total for key, value in counts.items() if value > 0}
+
+
+def _normalize_shares(shares: Mapping[str, float]) -> Mapping[str, float]:
+    total = sum(shares.values())
+    if total == 0:
+        return {}
+    return {key: value / total for key, value in shares.items() if value > 0}
+
+
+def _jensen_shannon_divergence(
+    observed: Mapping[str, float], baseline: Mapping[str, float]
+) -> float:
+    if not observed and not baseline:
+        return 0.0
+    keys = set(observed) | set(baseline)
+    if not keys:
+        return 0.0
+    m: Dict[str, float] = {}
+    for key in keys:
+        m[key] = 0.5 * observed.get(key, 0.0) + 0.5 * baseline.get(key, 0.0)
+    divergence = 0.0
+    for key in keys:
+        o = observed.get(key, 0.0)
+        b = baseline.get(key, 0.0)
+        if o > 0:
+            divergence += 0.5 * _kl_term(o, m[key])
+        if b > 0:
+            divergence += 0.5 * _kl_term(b, m[key])
+    return divergence
+
+
+def _kl_term(p: float, q: float) -> float:
+    if p == 0 or q == 0:
+        return 0.0
+    return p * log2(p / q)

--- a/src/monitoring/io.py
+++ b/src/monitoring/io.py
@@ -1,0 +1,55 @@
+"""IO helpers for monitoring datasets."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict, Mapping
+
+from zoneinfo import ZoneInfo
+
+from .detectors import SourceBaseline, SourceWindowStats
+from .reporting import MonitoringDataset
+
+UTC = ZoneInfo("UTC")
+
+
+def _parse_iso(timestamp: str) -> datetime:
+    return datetime.fromisoformat(timestamp).astimezone(UTC)
+
+
+def load_monitoring_dataset(payload: Mapping[str, Any]) -> MonitoringDataset:
+    window_start = _parse_iso(payload["window"]["start"])
+    window_end = _parse_iso(payload["window"]["end"])
+    baselines: Dict[str, SourceBaseline] = {}
+    for source_id, data in payload["baselines"].items():
+        baselines[source_id] = SourceBaseline(
+            expected_articles_per_window=float(data["expected_articles_per_window"]),
+            max_gap_hours=float(data["max_gap_hours"]),
+            language_distribution=data.get("language_distribution", {}),
+            topic_distribution=data.get("topic_distribution", {}),
+        )
+    source_windows = []
+    for item in payload["source_windows"]:
+        source_windows.append(
+            SourceWindowStats(
+                source_id=item["source_id"],
+                window_start=_parse_iso(item["window_start"]),
+                window_end=_parse_iso(item["window_end"]),
+                articles_found=int(item["articles_found"]),
+                expected_count=int(item.get("expected_count", item["articles_found"])),
+                last_article_at=_parse_iso(item["last_article_at"])
+                if item.get("last_article_at")
+                else None,
+                consecutive_failures=int(item.get("consecutive_failures", 0)),
+                schema_violations=int(item.get("schema_violations", 0)),
+                languages=item.get("languages", {}),
+                topics=item.get("topics", {}),
+            )
+        )
+    return MonitoringDataset(
+        window_start=window_start,
+        window_end=window_end,
+        source_windows=source_windows,
+        baselines=baselines,
+        schema_samples=payload.get("schema_samples", []),
+    )

--- a/src/monitoring/reporting.py
+++ b/src/monitoring/reporting.py
@@ -1,0 +1,113 @@
+"""Reporting orchestration for monitoring outputs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import List, Mapping, Optional, Sequence
+
+from zoneinfo import ZoneInfo
+
+from .canary import AutoSuppressionManager, CanaryRunner, build_canary_alerts
+from .common import Alert, Metric, MonitoringPayload
+from .detectors import (
+    ContentShiftDetector,
+    SchemaDriftDetector,
+    SchemaExpectation,
+    SourceBaseline,
+    SourceOutageDetector,
+    SourceOutageDetectorConfig,
+    SourceWindowStats,
+)
+
+UTC = ZoneInfo("UTC")
+
+
+@dataclass(slots=True)
+class MonitoringDataset:
+    """Bundle of inputs required by the monitoring orchestrator."""
+
+    window_start: datetime
+    window_end: datetime
+    source_windows: Sequence[SourceWindowStats]
+    baselines: Mapping[str, SourceBaseline]
+    schema_samples: Sequence[Mapping[str, object]]
+
+
+@dataclass(slots=True)
+class QualityReportGenerator:
+    """Runs detectors and assembles the weekly monitoring payload."""
+
+    schema_detector: SchemaDriftDetector
+    outage_detector: SourceOutageDetector
+    content_detector: ContentShiftDetector
+    canary_runner: CanaryRunner
+    suppression_manager: AutoSuppressionManager
+
+    def generate(self, dataset: MonitoringDataset) -> MonitoringPayload:
+        schema_result = self.schema_detector.evaluate(dataset.schema_samples)
+        outage_result = self.outage_detector.evaluate(
+            dataset.source_windows, dataset.baselines
+        )
+        content_result = self.content_detector.evaluate(
+            dataset.source_windows, dataset.baselines
+        )
+        metrics: List[Metric] = []
+        anomalies = []
+        for bag in (schema_result, outage_result, content_result):
+            metrics.extend(bag["metrics"])
+            anomalies.extend(bag["anomalies"])
+        canary_results = self.canary_runner.execute(dataset.source_windows)
+        alerts: List[Alert] = build_canary_alerts(canary_results)
+        suppression_decisions = self.suppression_manager.evaluate(
+            dataset.source_windows, anomalies
+        )
+        metrics.append(
+            Metric(
+                name="sources.auto_suppressed",
+                value=float(len(suppression_decisions)),
+            )
+        )
+        metadata = {
+            "suppressed_sources": [decision.source_id for decision in suppression_decisions],
+        }
+        return MonitoringPayload.from_components(
+            window_start=dataset.window_start,
+            window_end=dataset.window_end,
+            metrics=metrics,
+            anomalies=anomalies,
+            alerts=alerts,
+            metadata=metadata,
+        )
+
+
+def default_quality_report_generator(
+    schema_expectation: Optional[SchemaExpectation] = None,
+    canary_runner: Optional[CanaryRunner] = None,
+) -> QualityReportGenerator:
+    expectation = schema_expectation or SchemaExpectation(
+        required_fields={
+            "article_id": str,
+            "source_id": str,
+            "published_at": str,
+            "language": str,
+            "topics": list,
+            "title": str,
+        },
+        optional_fields={
+            "summary": str,
+            "content": str,
+            "authors": list,
+        },
+    )
+    outage_detector = SourceOutageDetector(SourceOutageDetectorConfig())
+    content_detector = ContentShiftDetector()
+    runner = canary_runner or CanaryRunner([])
+    suppression_manager = AutoSuppressionManager()
+    return QualityReportGenerator(
+        schema_detector=SchemaDriftDetector(expectation),
+        outage_detector=outage_detector,
+        content_detector=content_detector,
+        canary_runner=runner,
+        suppression_manager=suppression_manager,
+    )

--- a/tests/data/monitoring/outage_replay.json
+++ b/tests/data/monitoring/outage_replay.json
@@ -1,0 +1,66 @@
+{
+  "window": {
+    "start": "2025-01-24T00:00:00+00:00",
+    "end": "2025-01-31T00:00:00+00:00"
+  },
+  "baselines": {
+    "nature": {
+      "expected_articles_per_window": 5,
+      "max_gap_hours": 6,
+      "language_distribution": {"en": 0.9, "es": 0.1},
+      "topic_distribution": {"biology": 0.6, "physics": 0.4}
+    },
+    "science": {
+      "expected_articles_per_window": 4,
+      "max_gap_hours": 8,
+      "language_distribution": {"en": 1.0},
+      "topic_distribution": {"biology": 0.5, "astronomy": 0.5}
+    }
+  },
+  "source_windows": [
+    {
+      "source_id": "nature",
+      "window_start": "2025-01-30T18:00:00+00:00",
+      "window_end": "2025-01-31T00:00:00+00:00",
+      "articles_found": 0,
+      "expected_count": 5,
+      "last_article_at": "2025-01-28T00:00:00+00:00",
+      "consecutive_failures": 4,
+      "schema_violations": 0,
+      "languages": {"en": 0},
+      "topics": {}
+    },
+    {
+      "source_id": "science",
+      "window_start": "2025-01-30T18:00:00+00:00",
+      "window_end": "2025-01-31T00:00:00+00:00",
+      "articles_found": 6,
+      "expected_count": 4,
+      "last_article_at": "2025-01-30T23:00:00+00:00",
+      "consecutive_failures": 0,
+      "schema_violations": 0,
+      "languages": {"en": 6},
+      "topics": {"astronomy": 6}
+    }
+  ],
+  "schema_samples": [
+    {
+      "article_id": "nature-001",
+      "source_id": "nature",
+      "published_at": "2025-01-25T10:00:00+00:00",
+      "language": "en",
+      "topics": ["biology"],
+      "title": "Breakthrough",
+      "summary": "Sample"
+    },
+    {
+      "article_id": "science-001",
+      "source_id": "science",
+      "published_at": "2025-01-30T09:00:00+00:00",
+      "language": "en",
+      "topics": ["astronomy"],
+      "title": "Black holes",
+      "summary": "Sample"
+    }
+  ]
+}

--- a/tests/test_monitoring_anomalies.py
+++ b/tests/test_monitoring_anomalies.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+import sys
+
+import json
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC_DIR = ROOT / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+from monitoring import (
+    AutoSuppressionManager,
+    CanaryCheck,
+    CanaryRunner,
+    ContentShiftDetector,
+    MonitoringDataset,
+    SchemaDriftDetector,
+    SchemaExpectation,
+    SourceBaseline,
+    SourceOutageDetector,
+    SourceOutageDetectorConfig,
+    SourceWindowStats,
+    default_quality_report_generator,
+)
+from monitoring.canary import build_canary_alerts
+from monitoring.common import Severity
+from monitoring.detectors import ContentShiftThresholds
+from monitoring.io import load_monitoring_dataset
+
+
+UTC = timezone.utc
+
+
+def _now() -> datetime:
+    return datetime(2025, 2, 1, 12, 0, 0, tzinfo=UTC)
+
+
+def make_source_window(
+    source_id: str,
+    articles: int,
+    failures: int,
+    last_seen_hours: float,
+    languages: dict[str, int] | None = None,
+    topics: dict[str, int] | None = None,
+) -> SourceWindowStats:
+    now = _now()
+    last_article = now - timedelta(hours=last_seen_hours) if last_seen_hours is not None else None
+    return SourceWindowStats(
+        source_id=source_id,
+        window_start=now - timedelta(hours=6),
+        window_end=now,
+        articles_found=articles,
+        expected_count=6,
+        last_article_at=last_article,
+        consecutive_failures=failures,
+        schema_violations=0,
+        languages=languages or {"en": articles},
+        topics=topics or {"biology": articles},
+    )
+
+
+def test_source_outage_detector_flags_drop() -> None:
+    detector = SourceOutageDetector(
+        SourceOutageDetectorConfig(warn_ratio=0.6, alert_ratio=0.3, consecutive_failure_threshold=3),
+        now=_now(),
+    )
+    baselines = {
+        "nature": SourceBaseline(
+            expected_articles_per_window=5,
+            max_gap_hours=8,
+            language_distribution={"en": 0.9, "es": 0.1},
+            topic_distribution={"biology": 0.6, "physics": 0.4},
+        )
+    }
+    stats = [make_source_window("nature", articles=0, failures=4, last_seen_hours=10.0)]
+    result = detector.evaluate(stats, baselines)
+    assert result["anomalies"], "Expected outage anomaly"
+    anomaly = result["anomalies"][0]
+    assert anomaly.severity == Severity.CRITICAL
+    assert "consecutive" in anomaly.message
+
+
+def test_schema_drift_detector_missing_field() -> None:
+    expectation = SchemaExpectation(
+        required_fields={"article_id": str, "title": str},
+        optional_fields={"summary": str},
+        max_missing_ratio=0.1,
+    )
+    detector = SchemaDriftDetector(expectation)
+    samples = [
+        {"article_id": "a", "title": "One"},
+        {"article_id": "b", "title": "Two"},
+        {"article_id": "c"},
+    ]
+    result = detector.evaluate(samples)
+    assert any(a.labels.get("field") == "title" for a in result["anomalies"])
+
+
+def test_content_shift_detector_raises_alert() -> None:
+    thresholds = ContentShiftThresholds(
+        language_divergence_alert=0.2,
+        topic_divergence_alert=0.2,
+    )
+    detector = ContentShiftDetector(thresholds)
+    baselines = {
+        "nature": SourceBaseline(
+            expected_articles_per_window=5,
+            max_gap_hours=8,
+            language_distribution={"en": 0.9},
+            topic_distribution={"biology": 0.7, "physics": 0.3},
+        )
+    }
+    stats = [
+        make_source_window(
+            "nature",
+            articles=5,
+            failures=0,
+            last_seen_hours=1.0,
+            languages={"es": 5},
+            topics={"politics": 5},
+        )
+    ]
+    result = detector.evaluate(stats, baselines)
+    severities = {anomaly.severity for anomaly in result["anomalies"]}
+    assert Severity.CRITICAL in severities
+
+
+def test_canary_alert_and_suppression() -> None:
+    stats = [make_source_window("nature", articles=0, failures=3, last_seen_hours=72.0)]
+    baselines = {
+        "nature": SourceBaseline(
+            expected_articles_per_window=5,
+            max_gap_hours=6,
+            language_distribution={"en": 1.0},
+            topic_distribution={"biology": 1.0},
+        )
+    }
+    outage_result = SourceOutageDetector(now=_now()).evaluate(stats, baselines)
+    runner = CanaryRunner([CanaryCheck(source_id="nature", max_latency_ms=1000, max_idle_hours=12.0)])
+    canary_results = runner.execute(stats)
+    alerts = build_canary_alerts(canary_results)
+    assert alerts
+    suppression = AutoSuppressionManager(failure_threshold=1, idle_hours_threshold=48.0)
+    decisions = suppression.evaluate(stats, outage_result["anomalies"])
+    assert decisions and decisions[0].source_id == "nature"
+
+
+def test_quality_report_generator_builds_payload() -> None:
+    stats = [make_source_window("nature", articles=0, failures=3, last_seen_hours=72.0)]
+    baselines = {
+        "nature": SourceBaseline(
+            expected_articles_per_window=5,
+            max_gap_hours=6,
+            language_distribution={"en": 1.0},
+            topic_distribution={"biology": 1.0},
+        )
+    }
+    dataset = MonitoringDataset(
+        window_start=_now() - timedelta(days=7),
+        window_end=_now(),
+        source_windows=stats,
+        baselines=baselines,
+        schema_samples=[{"article_id": "a1", "title": "hello", "language": "en", "published_at": "2025-01-01T00:00:00Z", "topics": ["biology"], "source_id": "nature"}],
+    )
+    generator = default_quality_report_generator(
+        canary_runner=CanaryRunner([CanaryCheck("nature", max_latency_ms=1000, max_idle_hours=12.0)])
+    )
+    payload = generator.generate(dataset)
+    data = payload.to_dict()
+    assert data["status"] in {"warning", "critical"}
+    assert data["metadata"]["suppressed_sources"] == ["nature"]
+
+
+def test_load_monitoring_dataset_roundtrip(tmp_path) -> None:
+    now = _now()
+    payload = {
+        "window": {"start": (now - timedelta(days=7)).isoformat(), "end": now.isoformat()},
+        "baselines": {
+            "nature": {
+                "expected_articles_per_window": 5,
+                "max_gap_hours": 6,
+                "language_distribution": {"en": 1.0},
+                "topic_distribution": {"biology": 1.0},
+            }
+        },
+        "source_windows": [
+            {
+                "source_id": "nature",
+                "window_start": (now - timedelta(hours=6)).isoformat(),
+                "window_end": now.isoformat(),
+                "articles_found": 0,
+                "expected_count": 5,
+                "last_article_at": (now - timedelta(hours=10)).isoformat(),
+                "consecutive_failures": 4,
+                "schema_violations": 0,
+                "languages": {"en": 0},
+                "topics": {},
+            }
+        ],
+        "schema_samples": [
+            {
+                "article_id": "a1",
+                "source_id": "nature",
+                "published_at": now.isoformat(),
+                "language": "en",
+                "topics": ["biology"],
+                "title": "hello",
+            }
+        ],
+    }
+    dataset = load_monitoring_dataset(payload)
+    generator = default_quality_report_generator(
+        canary_runner=CanaryRunner([CanaryCheck("nature", max_latency_ms=1000, max_idle_hours=6.0)])
+    )
+    report = generator.generate(dataset)
+    assert report.metadata["suppressed_sources"] == ["nature"]
+    # ensure serialization roundtrip
+    text = json.dumps(report.to_dict())
+    assert "monitoring.v1" in text


### PR DESCRIPTION
## Summary
- add a dedicated monitoring package with shared payload schema, anomaly detectors, and canary auto-suppression utilities
- document the common monitoring output format and ship CLI tooling for weekly reports plus outage replays
- cover the new functionality with unit tests and canned outage fixtures for replay evidence

## Testing
- `pytest tests/test_monitoring_anomalies.py`
- `python scripts/replay_outage.py tests/data/monitoring/outage_replay.json`


------
https://chatgpt.com/codex/tasks/task_e_68dc13291a54832f8b8841d6d7f3e403