### PR TITLE
Update NEJM RSS feed URL

### DIFF
--- a/config/sources.py
+++ b/config/sources.py
@@ -59,7 +59,7 @@ ELITE_JOURNALS = {
     },
     "nejm": {
         "name": "New England Journal of Medicine",
-        "url": "https://www.nejm.org/action/showFeed?type=etoc&feed=rss",
+        "url": "https://www.nejm.org/action/showFeed?jc=nejm&type=etoc&feed=rss",
         "credibility_score": 0.99,
         "update_frequency": "weekly",
         "category": "medicine",

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -1,0 +1,4 @@
+# Release Notes
+
+## 2025-09-30
+- Updated the New England Journal of Medicine RSS feed to `https://www.nejm.org/action/showFeed?jc=nejm&type=etoc&feed=rss` to restore access to the official electronic table of contents feed and avoid HTTP 403 responses. 


### PR DESCRIPTION
## Summary
- update the NEJM RSS catalog entry to the official eTOC feed with the `jc=nejm` query parameter
- add a release note documenting the NEJM feed adjustment

## Testing
- `python -c "from config.sources import validate_sources; validate_sources()"`
- `python run_collector.py --sources nejm --quiet`
- `RESPECT_ROBOTS=false python run_collector.py --sources nejm --quiet`
- `python - <<'PY'
import requests
url = "https://www.nejm.org/action/showFeed?jc=nejm&type=etoc&feed=rss"
resp = requests.get(url, timeout=10)
print(resp.status_code)
print(resp.headers.get('content-type'))
print(len(resp.content))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68dc33bad574832f83b98fecf3a091cf