### PR TITLE
Update Scientific American feed URL

### DIFF
--- a/config/sources.py
+++ b/config/sources.py
@@ -78,7 +78,7 @@ ELITE_JOURNALS = {
 SCIENCE_MEDIA = {
     "scientific_american": {
         "name": "Scientific American",
-        "url": "https://rss.sciam.com/ScientificAmerican-Global",
+        "url": "https://www.scientificamerican.com/platform/syndication/rss/",
         "credibility_score": 0.85,
         "update_frequency": "daily",
         "category": "popular_science",


### PR DESCRIPTION
## Summary
- update the Scientific American source to use the TLS-enabled syndication feed
- verify the collector can fetch the Scientific American feed without TLS handshake issues

## Testing
- python run_collector.py --sources scientific_american --quiet

------
https://chatgpt.com/codex/tasks/task_e_68dc352db4bc832f872360b11836a068