### PR TITLE
Update NIH RSS feed URL for institutional sources

### DIFF
--- a/config/sources.py
+++ b/config/sources.py
@@ -163,7 +163,7 @@ INSTITUTIONAL_SOURCES = {
     },
     "nih_news": {
         "name": "NIH News",
-        "url": "https://www.nih.gov/news-events/news-releases/rss.xml",
+        "url": "https://www.nih.gov/news-releases/feed.xml",
         "credibility_score": 0.95,
         "update_frequency": "weekly",
         "category": "medicine",


### PR DESCRIPTION
## Summary
- update the NIH institutional source configuration to use the current news releases feed
- validate the source catalog and run a targeted NIH collection to confirm successful ingestion

## Testing
- python - <<'PY'
from config.sources import validate_sources
validate_sources()
PY
- python main.py --sources nih_news --top 0

------
https://chatgpt.com/codex/tasks/task_e_68dc361f3d80832fa1d9f86c8018f68e