### PR TITLE
Implement conditional RSS feed caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Eso es exactamente lo que hace este sistema.
 - **Múltiples Formatos**: RSS, Atom, feeds institucionales
 - **Respeto por Servidores**: Rate limiting inteligente, manejo de errores robusto
   - Feeds comunitarios (ej. r/science) se consultan como máximo una vez por minuto para respetar el rate limit de Reddit (intervalos >=30s y user-agent dedicado)
+- **Caching Condicional**: Persistimos `ETag` y `Last-Modified` por fuente para enviar `If-None-Match`/`If-Modified-Since`, reduciendo ancho de banda y evitando descargas innecesarias cuando no hay contenido nuevo.
 - **Deduplicación**: Detección automática de contenido duplicado
 
 ### 🧠 Scoring Multidimensional

--- a/config/sources.py
+++ b/config/sources.py
@@ -2,6 +2,8 @@
 # Catálogo de fuentes RSS para News Collector
 # ===========================================
 
+from typing import Any, Dict
+
 """
 Este archivo define todas las fuentes de información que nuestro sistema
 monitoreará. Piensa en esto como crear una biblioteca curada de las mejores
@@ -231,13 +233,26 @@ COMMUNITY_FEEDS = {
 # ==================================
 # Aquí combinamos todas las categorías en una estructura unificada
 
-ALL_SOURCES = {
-    **ELITE_JOURNALS,
-    **SCIENCE_MEDIA,
-    **INSTITUTIONAL_SOURCES,
-    **PREPRINT_SOURCES,
-    **COMMUNITY_FEEDS,
-}
+def _with_feed_cache_fields(
+    sources: Dict[str, Dict[str, Any]]
+) -> Dict[str, Dict[str, Any]]:
+    """Ensure every source has optional feed cache metadata keys."""
+
+    for source in sources.values():
+        source.setdefault("etag", None)
+        source.setdefault("last_modified", None)
+    return sources
+
+
+ALL_SOURCES = _with_feed_cache_fields(
+    {
+        **ELITE_JOURNALS,
+        **SCIENCE_MEDIA,
+        **INSTITUTIONAL_SOURCES,
+        **PREPRINT_SOURCES,
+        **COMMUNITY_FEEDS,
+    }
+)
 
 # Configuraciones específicas por categoría
 # =========================================

--- a/docs/collector_runbook.md
+++ b/docs/collector_runbook.md
@@ -1,0 +1,34 @@
+# 🛠️ Collector Runbook
+
+## Overview
+The RSS collector fetches scientific feeds on a fixed cadence, applies polite rate limiting, and stores feed metadata for incremental polling. Operators can use this runbook to triage incidents and validate that caching is behaving as expected.
+
+## Conditional Fetch Caching
+- We persist the latest `ETag` and `Last-Modified` headers per source in the `sources` table (`feed_etag`, `feed_last_modified`).
+- Each request includes `If-None-Match` and `If-Modified-Since` when cached values exist. A `304 Not Modified` is treated as a successful poll with zero articles.
+- After a `200 OK`, updated headers are written back to the database so the next poll stays incremental. We also accept header refreshes on `304` responses.
+- You can inspect the cached values with:
+  ```bash
+  sqlite3 data/news.db "SELECT id, feed_etag, feed_last_modified FROM sources WHERE id='nature';"
+  ```
+- If a source stops issuing `ETag`/`Last-Modified`, clear the cache for that entry to force a full refresh:
+  ```bash
+  sqlite3 data/news.db "UPDATE sources SET feed_etag=NULL, feed_last_modified=NULL WHERE id='nature';"
+  ```
+
+## Incident Checklist
+1. **Spike in HTTP 304s**
+   - Confirm schedules: repeated 304s with zero articles are expected when no new stories land.
+   - Validate last article timestamps in the DB to ensure fresh posts are still detected.
+2. **Unexpected 200 payload despite cache**
+   - Inspect stored metadata to confirm the server rotated the ETag.
+   - Capture headers with `curl -I <feed>` and compare with stored values.
+3. **Server ignores validators**
+   - Disable caching temporarily by clearing metadata (see above) and set a reminder to re-enable once the provider fixes headers.
+4. **Database migration issues**
+   - Ensure the new columns exist: `PRAGMA table_info(sources);` should list `feed_etag` and `feed_last_modified`.
+
+## Verification Steps After Deploying Collector Changes
+1. Run `pytest tests/test_rate_limit_and_backoff.py -k conditional` to ensure regression coverage for cached headers.
+2. Trigger a dry run (`python run_collector.py --dry-run --sources nature`) and confirm logs show the conditional request headers.
+3. Review Grafana panels for fetch duration and response codes to verify fewer bytes transferred after deploying caching.

--- a/src/storage/models.py
+++ b/src/storage/models.py
@@ -322,6 +322,10 @@ class Source(Base):
     # ===================================
     custom_config = Column(JSON)  # Configuraciones especiales para esta fuente
 
+    # Metadatos HTTP para caching condicional
+    feed_etag = Column(String(512))
+    feed_last_modified = Column(String(100))
+
     def __repr__(self):
         return f"<Source(id='{self.id}', name='{self.name}', active={self.is_active})>"
 

--- a/tests/test_rate_limit_and_backoff.py
+++ b/tests/test_rate_limit_and_backoff.py
@@ -1,5 +1,49 @@
+import sys
 import time
+from pathlib import Path
+from types import MethodType
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
 from src.collectors.rss_collector import RSSCollector
+from src.storage.database import DatabaseManager
+
+
+class DummyResponse:
+    def __init__(self, status_code, headers=None, text=""):
+        self.status_code = status_code
+        self.headers = headers or {}
+        self._text = text
+
+    @property
+    def text(self):
+        return self._text
+
+    @property
+    def content(self):
+        return self._text.encode("utf-8")
+
+    def raise_for_status(self):
+        if 400 <= self.status_code < 600:
+            raise Exception(f"HTTP {self.status_code}")
+
+
+def _setup_collector(tmp_path, monkeypatch):
+    db_path = tmp_path / "test.db"
+    db_manager = DatabaseManager({"type": "sqlite", "path": db_path})
+    monkeypatch.setattr(
+        "src.collectors.rss_collector.get_database_manager", lambda: db_manager
+    )
+    collector = RSSCollector()
+    source_config = {
+        "name": "Test Feed",
+        "url": "https://example.com/feed.xml",
+        "credibility_score": 0.5,
+        "category": "testing",
+        "update_frequency": "daily",
+    }
+    db_manager.initialize_sources({"test_source": source_config})
+    return collector, db_manager, source_config
 
 
 def test_backoff_monotonic_small():
@@ -10,3 +54,74 @@ def test_backoff_monotonic_small():
         c._backoff_sleep(attempt)
         elapsed = time.perf_counter() - start
         assert elapsed >= 0
+
+
+def test_fetch_feed_uses_conditional_headers(tmp_path, monkeypatch):
+    collector, db_manager, source_config = _setup_collector(tmp_path, monkeypatch)
+    db_manager.update_source_feed_metadata(
+        "test_source",
+        etag='"old-etag"',
+        last_modified="Wed, 21 Oct 2015 07:28:00 GMT",
+    )
+
+    captured = {}
+
+    def fake_get(self, url, timeout, headers=None):
+        captured["headers"] = headers
+        return DummyResponse(
+            200,
+            headers={
+                "ETag": '"new-etag"',
+                "Last-Modified": "Mon, 01 Jan 2024 00:00:00 GMT",
+                "content-type": "application/rss+xml",
+            },
+            text="<rss></rss>",
+        )
+
+    collector.session.get = MethodType(fake_get, collector.session)
+    content, status = collector._fetch_feed("test_source", source_config["url"])
+
+    assert status == 200
+    assert content == "<rss></rss>"
+    assert captured["headers"]["If-None-Match"] == '"old-etag"'
+    assert captured["headers"]["If-Modified-Since"] == "Wed, 21 Oct 2015 07:28:00 GMT"
+
+    updated = db_manager.get_source_feed_metadata("test_source")
+    assert updated["etag"] == '"new-etag"'
+    assert updated["last_modified"] == "Mon, 01 Jan 2024 00:00:00 GMT"
+
+
+def test_collect_from_source_handles_not_modified(tmp_path, monkeypatch):
+    collector, db_manager, source_config = _setup_collector(tmp_path, monkeypatch)
+    db_manager.update_source_feed_metadata(
+        "test_source",
+        etag='"cached"',
+        last_modified="Tue, 02 Jan 2024 00:00:00 GMT",
+    )
+
+    captured = {}
+
+    def fake_get(self, url, timeout, headers=None):
+        captured["headers"] = headers
+        return DummyResponse(
+            304,
+            headers={
+                "ETag": '"cached"',
+                "Last-Modified": "Tue, 02 Jan 2024 00:00:00 GMT",
+            },
+        )
+
+    collector.session.get = MethodType(fake_get, collector.session)
+    collector._respect_robots = lambda url: (True, None)
+    collector._enforce_domain_rate_limit = lambda domain, robots_delay: None
+
+    stats = collector.collect_from_source("test_source", source_config)
+
+    assert stats["success"] is True
+    assert stats["articles_found"] == 0
+    assert stats["articles_saved"] == 0
+    assert captured["headers"]["If-None-Match"] == '"cached"'
+
+    metadata = db_manager.get_source_feed_metadata("test_source")
+    assert metadata["etag"] == '"cached"'
+    assert metadata["last_modified"] == "Tue, 02 Jan 2024 00:00:00 GMT"


### PR DESCRIPTION
## Summary
- add optional feed validator fields to source definitions and database schema
- send If-None-Match/If-Modified-Since headers during RSS fetches and store updated ETag metadata
- extend regression tests and documentation to cover the conditional caching workflow

## Testing
- pytest tests/test_rate_limit_and_backoff.py


------
https://chatgpt.com/codex/tasks/task_e_68dc52568170832f901086d89eb9387a