### PR TITLE
Add collector pipeline E2E test fixtures

### DIFF
--- a/docs/fixtures.md
+++ b/docs/fixtures.md
@@ -1,0 +1,57 @@
+# Fixture Maintenance Guide
+
+This document explains how to maintain the golden datasets used by the end-to-end
+collector pipeline tests. The goal is to keep `tests/data/golden_articles.json`
+and the chained fixture `tests/data/collector_pipeline_chain.json` in sync with the
+current schemas for collector payloads, enrichment outputs, and storage rows.
+
+## When to Refresh Fixtures
+
+Refresh the fixtures whenever one of the following happens:
+
+- The collector contract (`CollectorArticleModel`) gains or changes required fields.
+- The enrichment pipeline updates its payload schema or output semantics.
+- Storage models (`Article`, `ScoreLog`) evolve in a way that changes persisted
+  columns validated by the tests.
+- Scoring logic adds new components or renames existing ones.
+
+## Refresh Procedure
+
+1. **Regenerate enrichment expectations**
+   - Update `tests/data/golden_articles.json` so that it reflects the latest
+     enrichment outputs for your canonical article samples.
+   - If you have added new samples, ensure their `expected` block mirrors the
+     deterministic enrichment pipeline output.
+
+2. **Rebuild the chained pipeline fixture**
+   - Copy the structure used in `tests/data/collector_pipeline_chain.json` for
+     each article (source metadata, collector payload, expected storage fields).
+   - For new schema fields, add the minimum values required by
+     `CollectorArticleModel` and by the scoring/storage contracts.
+   - Keep summaries at least `TEXT_PROCESSING_CONFIG["min_content_length"]`
+     characters so validation passes.
+
+3. **Validate with the E2E test**
+   - Run `pytest -s tests/test_collector_pipeline_e2e.py` to execute the mocked
+     pipeline.
+   - The test writes a reconciliation artifact listing expected vs. actual
+     fields. Copy the printed `pipeline_reconciliation_artifact=...` path and
+     inspect the JSON to confirm the new schema is represented correctly.
+
+4. **Iterate until clean**
+   - Adjust fixture entries until the test passes without diffs outside the
+     acceptable tolerances (language, sentiment, topics/entities containment,
+     score thresholds, etc.).
+
+5. **Commit the updates**
+   - Commit changes to the fixture JSON files together with any schema or code
+     updates so CI runs against matching expectations.
+
+## Tips
+
+- When schemas gain optional fields, prefer adding them to the fixture so the
+  pipeline test exercises the new shape early.
+- If scoring parameters change, bump the `final_score_min` guardrails rather than
+  hard-coding exact scores—this keeps the test resilient to minor tuning.
+- Keep the reconciliation artifact from the latest run attached to CI logs; it
+  provides fast feedback when the pipeline diverges from the expected fixtures.

--- a/tests/data/collector_pipeline_chain.json
+++ b/tests/data/collector_pipeline_chain.json
@@ -1,0 +1,116 @@
+[
+  {
+    "id": "en-01",
+    "source": {
+      "id": "test_science_daily",
+      "name": "Science Daily Test",
+      "url": "https://example.com/science/rss",
+      "category": "science",
+      "credibility_score": 0.92,
+      "language": "en"
+    },
+    "collector_raw": {
+      "url": "https://example.com/articles/nasa-confirms-water-on-mars",
+      "title": "NASA Confirms Water on Mars",
+      "summary": "NASA scientists announced that Mars shows positive water traces during research. The mission team confirmed repeated detections using multiple instruments, offering robust evidence for hydrating minerals across the planet's surface with ongoing analysis providing further validation.",
+      "authors": ["NASA Science Team"],
+      "published_offset_hours": -6,
+      "source_metadata": {
+        "feed_title": "Science Daily",
+        "content": "NASA scientists announced that Mars shows positive water traces during research, confirming hydrated minerals across the surface and outlining the next mission milestones.",
+        "doi": "10.1000/nasa-mars-water"
+      }
+    },
+    "enrichment_expected": {
+      "language": "en",
+      "sentiment": "positive",
+      "topics": ["space", "science"],
+      "entities": ["NASA", "Mars"]
+    },
+    "expected_storage": {
+      "fields": {
+        "language": "en",
+        "category": "science",
+        "source_id": "test_science_daily"
+      },
+      "final_score_min": 0.4,
+      "should_include": true
+    }
+  },
+  {
+    "id": "en-04",
+    "source": {
+      "id": "test_market_watch",
+      "name": "Market Watch Test",
+      "url": "https://example.com/markets/rss",
+      "category": "economy",
+      "credibility_score": 0.68,
+      "language": "en"
+    },
+    "collector_raw": {
+      "url": "https://example.com/articles/markets-face-global-decline",
+      "title": "Markets Face Global Decline",
+      "summary": "Wall Street analysts warned about market decline and economic crisis in a lengthy briefing. The report highlighted sustained losses, liquidity concerns, and macroeconomic uncertainty that continues to pressure investors across major exchanges worldwide.",
+      "authors": ["Financial Research Desk"],
+      "published_offset_hours": -20,
+      "source_metadata": {
+        "feed_title": "Market Watch",
+        "content": "Wall Street analysts warned about market decline and economic crisis, citing macroeconomic uncertainty and liquidity stress in international exchanges.",
+        "doi": null
+      }
+    },
+    "enrichment_expected": {
+      "language": "en",
+      "sentiment": "negative",
+      "topics": ["economy"],
+      "entities": ["Wall Street"]
+    },
+    "expected_storage": {
+      "fields": {
+        "language": "en",
+        "category": "economy",
+        "source_id": "test_market_watch"
+      },
+      "final_score_min": 0.3,
+      "should_include": true
+    }
+  },
+  {
+    "id": "es-08",
+    "source": {
+      "id": "test_tecnologia",
+      "name": "Tecnología Hoy Test",
+      "url": "https://example.com/tecnologia/rss",
+      "category": "technology",
+      "credibility_score": 0.88,
+      "language": "es"
+    },
+    "collector_raw": {
+      "url": "https://example.com/articulos/google-y-telefonica-colaboran",
+      "title": "Google y Telefónica colaboran en IA",
+      "summary": "Google y Telefónica anunciaron un proyecto de tecnología IA con impacto positivo en software y redes. La alianza destaca inversiones en investigación, capacitación regional y despliegue de plataformas inteligentes para clientes empresariales.",
+      "authors": ["Redacción Innovación"],
+      "published_offset_hours": -3,
+      "source_metadata": {
+        "feed_title": "Tecnología Hoy",
+        "content": "Google y Telefónica anunciaron un proyecto de tecnología IA con impacto positivo en software, capacitación y redes latinoamericanas.",
+        "doi": null
+      }
+    },
+    "enrichment_expected": {
+      "language": "es",
+      "sentiment": "positive",
+      "topics": ["technology"],
+      "entities": ["Google", "Telefónica", "IA"]
+    },
+    "expected_storage": {
+      "fields": {
+        "language": "es",
+        "category": "technology",
+        "source_id": "test_tecnologia"
+      },
+      "final_score_min": 0.4,
+      "should_include": true
+    }
+  }
+]

--- a/tests/test_collector_pipeline_e2e.py
+++ b/tests/test_collector_pipeline_e2e.py
@@ -1,0 +1,187 @@
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Dict, List
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from src.collectors import RSSCollector
+from src.scoring import create_scorer
+from src.storage import models as storage_models
+from src.storage.database import DatabaseManager
+
+
+FIXTURE_PATH = Path(__file__).resolve().parent / "data" / "collector_pipeline_chain.json"
+
+
+@pytest.fixture(scope="module")
+def pipeline_dataset() -> List[Dict[str, object]]:
+    with FIXTURE_PATH.open(encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+@pytest.fixture()
+def isolated_database(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> DatabaseManager:
+    db_path = tmp_path / "pipeline.db"
+    manager = DatabaseManager({"type": "sqlite", "path": db_path})
+
+    import src.storage.database as database_module
+
+    # Reset singleton for test isolation
+    monkeypatch.setattr(database_module, "_db_manager", manager, raising=False)
+    monkeypatch.setattr(
+        "src.collectors.rss_collector.get_database_manager", lambda: manager
+    )
+
+    return manager
+
+
+def _prepare_raw_article(entry: Dict[str, object]) -> Dict[str, object]:
+    collector_raw = dict(entry["collector_raw"])  # shallow copy
+    offset_hours = collector_raw.pop("published_offset_hours")
+    published_dt = datetime.now(timezone.utc) + timedelta(hours=offset_hours)
+    collector_raw["published_date"] = published_dt
+    collector_raw.setdefault("published_tz_offset_minutes", 0)
+    collector_raw.setdefault("published_tz_name", "UTC")
+    collector_raw.setdefault("original_url", collector_raw["url"])
+    collector_raw.setdefault("source_metadata", {})
+    return collector_raw
+
+
+def test_collector_pipeline_end_to_end(
+    isolated_database: DatabaseManager, pipeline_dataset: List[Dict[str, object]], tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    collector = RSSCollector()
+
+    # Mock external IO interactions
+    monkeypatch.setattr(RSSCollector, "_respect_robots", lambda self, url: (True, None))
+    monkeypatch.setattr(
+        RSSCollector,
+        "_enforce_domain_rate_limit",
+        lambda self, domain, robots_delay, source_min_delay=None: None,
+    )
+    monkeypatch.setattr(
+        RSSCollector, "_fetch_feed", lambda self, source_id, feed_url: ("<rss/>", 200)
+    )
+
+    dummy_feed = type("DummyFeed", (), {"bozo": 0})()
+    monkeypatch.setattr("feedparser.parse", lambda content: dummy_feed)
+
+    def fake_extract(self, parsed_feed, source_config):
+        return getattr(self, "_test_articles", [])
+
+    monkeypatch.setattr(RSSCollector, "_extract_articles_from_feed", fake_extract)
+
+    recon_records: List[Dict[str, object]] = []
+
+    scorer = create_scorer()
+
+    for entry in pipeline_dataset:
+        source = entry["source"]
+        raw_article = _prepare_raw_article(entry)
+        collector._test_articles = [raw_article]
+
+        source_config = {
+            "name": source["name"],
+            "url": source["url"],
+            "category": source["category"],
+            "credibility_score": source["credibility_score"],
+            "language": source.get("language", "en"),
+        }
+
+        stats = collector.collect_from_source(source["id"], source_config)
+
+        assert stats["success"] is True
+        assert stats["articles_saved"] == 1
+
+        with isolated_database.get_session() as session:
+            stored_article = (
+                session.query(storage_models.Article)
+                .filter_by(url=raw_article["url"])
+                .first()
+            )
+            assert stored_article is not None, "article should be persisted"
+            enrichment = stored_article.article_metadata.get("enrichment", {})
+
+        expected_enrichment = entry["enrichment_expected"]
+        assert enrichment.get("language") == expected_enrichment["language"]
+        assert enrichment.get("sentiment") == expected_enrichment["sentiment"]
+        actual_topics = enrichment.get("topics", [])
+        for topic in expected_enrichment["topics"]:
+            assert topic in actual_topics
+        actual_entities = enrichment.get("entities", [])
+        for entity in expected_enrichment["entities"]:
+            assert entity in actual_entities
+
+        score_payload = scorer.score_article(stored_article)
+        assert score_payload["should_include"] == entry["expected_storage"]["should_include"]
+
+        updated = isolated_database.update_article_score(
+            stored_article.id, score_payload
+        )
+        assert updated is True
+
+        with isolated_database.get_session() as session:
+            post_article = (
+                session.query(storage_models.Article)
+                .filter_by(id=stored_article.id)
+                .first()
+            )
+            logs = (
+                session.query(storage_models.ScoreLog)
+                .filter_by(article_id=stored_article.id)
+                .all()
+            )
+
+        assert post_article is not None
+        assert len(logs) == 1
+
+        expected_fields = entry["expected_storage"]["fields"]
+        for field_name, expected_value in expected_fields.items():
+            assert getattr(post_article, field_name) == expected_value
+
+        assert post_article.processing_status == "completed"
+        assert post_article.final_score is not None
+        assert post_article.final_score >= entry["expected_storage"]["final_score_min"]
+        assert isinstance(post_article.score_components, dict)
+
+        for component_name in ("source_credibility", "recency", "content_quality", "engagement"):
+            component_value = post_article.score_components.get(component_name)
+            assert component_value is not None
+            assert 0.0 <= component_value <= 1.0
+
+        recon_records.append(
+            {
+                "id": entry["id"],
+                "expected": {
+                    **entry["expected_storage"],
+                    "enrichment": entry["enrichment_expected"],
+                },
+                "actual": {
+                    "language": post_article.language,
+                    "category": post_article.category,
+                    "source_id": post_article.source_id,
+                    "final_score": post_article.final_score,
+                    "processing_status": post_article.processing_status,
+                    "score_components": post_article.score_components,
+                    "should_include": score_payload["should_include"],
+                    "enrichment": enrichment,
+                },
+            }
+        )
+
+    with isolated_database.get_session() as session:
+        total_logs = session.query(storage_models.ScoreLog).count()
+    assert total_logs == len(pipeline_dataset)
+
+    artifact_path = tmp_path / "pipeline_reconciliation.json"
+    with artifact_path.open("w", encoding="utf-8") as fh:
+        json.dump({"entries": recon_records}, fh, ensure_ascii=False, indent=2)
+
+    # Attach artifact path to help CI collect it
+    print(f"pipeline_reconciliation_artifact={artifact_path}")


### PR DESCRIPTION
## Summary
- add a chained collector/enrichment/storage fixture dataset reusing the golden articles payloads
- create a mocked end-to-end pytest covering collector processing, scoring updates, and artifact reconciliation output
- document how to refresh the fixtures when schemas evolve

## Testing
- pytest tests/test_collector_pipeline_e2e.py

------
https://chatgpt.com/codex/tasks/task_e_68dc58f98fac832f8c3fd7a01248ceb6