### PR TITLE
Add scoring golden dataset and drift comparison tooling

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,76 @@
+# Contributing to Noticiencias News Collector
+
+Thanks for helping us keep the Noticiencias stack healthy! This document captures a few ground rules that are easy to miss when touching scoring logic or fixtures.
+
+## Local setup checklist
+
+1. Create a virtual environment and install dependencies with hash checking:
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   pip install --require-hashes -r requirements.lock
+   ```
+2. Before sending a PR run:
+   ```bash
+   pytest
+   ruff check src tests
+   mypy src
+   ```
+3. Use descriptive commits and keep diffs focused. Every behavioural change should include a matching test.
+
+## Updating golden scoring data
+
+When you intentionally change the scoring logic, refresh the regression fixtures so other contributors understand the delta:
+
+1. Inspect the drift between the baseline and your branch:
+   ```bash
+   python scripts/score_delta.py --dataset tests/data/scoring_golden.json
+   ```
+   The command reports precision@K against the stored baseline along with coverage of previously surfaced articles.
+2. If the differences are expected, regenerate the golden file using a frozen timestamp (keeps tests deterministic):
+   ```bash
+   python - <<'PY'
+   from datetime import datetime, timezone
+   import json
+   from pathlib import Path
+   from types import SimpleNamespace
+
+   from src.scoring import feature_scorer
+   from src.scoring.feature_scorer import FeatureBasedScorer
+
+   data_path = Path("tests/data/scoring_golden.json")
+   payload = json.loads(data_path.read_text(encoding="utf-8"))
+   frozen_at = datetime.now(timezone.utc)
+
+   class Frozen(datetime):
+       @classmethod
+       def now(cls, tz=None):
+           return frozen_at.astimezone(tz) if tz else frozen_at
+
+   feature_scorer.datetime = Frozen
+
+   scorer = FeatureBasedScorer()
+   articles = payload["articles"]
+   for item in articles:
+       article = SimpleNamespace(**item["article"])
+       score = scorer.score_article(article)
+       item["expected"].update(
+           final_score=score["final_score"],
+           should_include=score["should_include"],
+           components=score["components"],
+           penalties=score["penalties"],
+       )
+   payload["frozen_at"] = frozen_at.isoformat().replace("+00:00", "Z")
+   data_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+   PY
+   ```
+3. Commit the regenerated fixture together with the code change so CI and reviewers see the expected impact.
+
+## Pull request hygiene
+
+- Keep PR descriptions action-oriented (what changed + why).
+- Link related tickets or incident reports when applicable.
+- Run `make format` if the CI formatter complains.
+- Observe our security policy: never commit credentials or raw PII.
+
+Happy shipping! 🚀

--- a/scripts/score_delta.py
+++ b/scripts/score_delta.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python
+"""Compare current scorer outputs against a baseline snapshot."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Dict, Iterable, List, Mapping, Sequence
+
+ROOT = Path(__file__).resolve().parents[1]
+import sys
+
+sys.path.insert(0, str(ROOT))
+
+from src.scoring import feature_scorer
+from src.scoring.feature_scorer import FeatureBasedScorer
+
+
+@dataclass
+class ArticleResult:
+    article_id: str
+    final_score: float
+    should_include: bool
+    baseline_score: float | None = None
+    baseline_should_include: bool | None = None
+
+    @property
+    def score_delta(self) -> float | None:
+        if self.baseline_score is None:
+            return None
+        return self.final_score - self.baseline_score
+
+
+@dataclass
+class Dataset:
+    entries: List[Dict[str, object]]
+    frozen_at: datetime | None
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--dataset",
+        type=Path,
+        default=ROOT / "tests" / "data" / "scoring_golden.json",
+        help="Path to JSON with article payloads. Defaults to the scoring golden dataset.",
+    )
+    parser.add_argument(
+        "--baseline",
+        type=Path,
+        default=None,
+        help=(
+            "Optional JSON file containing baseline scores. "
+            "If omitted, expected values from the dataset are used when available."
+        ),
+    )
+    parser.add_argument(
+        "--top-k",
+        type=int,
+        action="append",
+        default=[5, 10],
+        help="K values for precision@K (can be repeated). Defaults to 5 and 10.",
+    )
+    parser.add_argument(
+        "--report-top",
+        type=int,
+        default=5,
+        help="Number of largest score deltas to display in the summary table.",
+    )
+    return parser.parse_args()
+
+
+def load_dataset(path: Path) -> Dataset:
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    frozen_at: datetime | None = None
+    if isinstance(raw, Mapping):
+        frozen = raw.get("frozen_at")
+        if isinstance(frozen, str):
+            frozen_at = datetime.fromisoformat(frozen.replace("Z", "+00:00"))
+        entries = raw.get("articles") or raw.get("items") or raw.get("samples")
+        if entries is None:
+            raise ValueError("Dataset JSON must contain an 'articles' array or be a list")
+    else:
+        entries = raw
+    if not isinstance(entries, list):
+        raise TypeError("Dataset entries must be a list")
+    return Dataset(entries=list(entries), frozen_at=frozen_at)
+
+
+def load_baseline(entries: Sequence[Dict[str, object]], baseline_path: Path | None) -> Dict[str, Dict[str, object]]:
+    if baseline_path is None:
+        baseline: Dict[str, Dict[str, object]] = {}
+        for entry in entries:
+            expected = entry.get("expected") if isinstance(entry, Mapping) else None
+            if isinstance(expected, Mapping):
+                article_id = str(entry.get("id") or entry.get("article", {}).get("id"))
+                baseline[article_id] = {
+                    "final_score": expected.get("final_score"),
+                    "should_include": expected.get("should_include"),
+                }
+        return baseline
+
+    raw = json.loads(baseline_path.read_text(encoding="utf-8"))
+    if isinstance(raw, Mapping) and "articles" in raw:
+        raw = raw["articles"]
+    baseline: Dict[str, Dict[str, object]] = {}
+    if isinstance(raw, Mapping):
+        iterator: Iterable = raw.items()
+        for article_id, payload in iterator:
+            if isinstance(payload, Mapping):
+                baseline[str(article_id)] = {
+                    "final_score": payload.get("final_score"),
+                    "should_include": payload.get("should_include"),
+                }
+    elif isinstance(raw, list):
+        for item in raw:
+            if not isinstance(item, Mapping):
+                continue
+            article_id = str(item.get("id"))
+            if not article_id:
+                continue
+            baseline[article_id] = {
+                "final_score": item.get("final_score"),
+                "should_include": item.get("should_include"),
+            }
+    else:
+        raise TypeError("Baseline payload must be a mapping or list")
+    return baseline
+
+
+def to_namespace(article_payload: Mapping[str, object]) -> SimpleNamespace:
+    prepared = dict(article_payload)
+    prepared.setdefault("article_metadata", {})
+    return SimpleNamespace(**prepared)
+
+
+@contextmanager
+def freeze_datetime(target: datetime | None):
+    if target is None:
+        yield
+        return
+    original = feature_scorer.datetime
+
+    class _FrozenDateTime(datetime):
+        @classmethod
+        def now(cls, tz=None):  # type: ignore[override]
+            if tz:
+                return target.astimezone(tz)
+            return target
+
+    feature_scorer.datetime = _FrozenDateTime
+    try:
+        yield
+    finally:
+        feature_scorer.datetime = original
+
+
+def score_articles(entries: Sequence[Dict[str, object]], baseline_map: Mapping[str, Dict[str, object]]) -> List[ArticleResult]:
+    scorer = FeatureBasedScorer()
+    results: List[ArticleResult] = []
+
+    for entry in entries:
+        article_info: Mapping[str, object]
+        if isinstance(entry, Mapping) and "article" in entry:
+            article_info = entry["article"]  # type: ignore[assignment]
+        else:
+            article_info = entry  # type: ignore[assignment]
+
+        article_id = str(
+            (entry.get("id") if isinstance(entry, Mapping) else None)
+            or article_info.get("id")
+        )
+        article_obj = to_namespace(article_info)
+        scored = scorer.score_article(article_obj)
+
+        baseline = baseline_map.get(article_id)
+        baseline_score = (
+            float(baseline["final_score"]) if baseline and baseline.get("final_score") is not None else None
+        )
+        baseline_include = (
+            bool(baseline["should_include"]) if baseline and baseline.get("should_include") is not None else None
+        )
+
+        results.append(
+            ArticleResult(
+                article_id=article_id,
+                final_score=float(scored["final_score"]),
+                should_include=bool(scored["should_include"]),
+                baseline_score=baseline_score,
+                baseline_should_include=baseline_include,
+            )
+        )
+
+    return results
+
+
+def precision_at_k(results: Sequence[ArticleResult], positives: Mapping[str, bool], k: int) -> float:
+    if k <= 0:
+        return 0.0
+    ranked = sorted(results, key=lambda item: item.final_score, reverse=True)[:k]
+    if not ranked:
+        return 0.0
+    hits = sum(1 for item in ranked if positives.get(item.article_id))
+    return hits / min(k, len(ranked))
+
+
+def compute_coverage(results: Sequence[ArticleResult], positives: Mapping[str, bool]) -> float:
+    baseline_positive_ids = {article_id for article_id, flag in positives.items() if flag}
+    if not baseline_positive_ids:
+        return 1.0
+    current_positive_ids = {item.article_id for item in results if item.should_include}
+    return len(baseline_positive_ids & current_positive_ids) / len(baseline_positive_ids)
+
+
+def main() -> None:
+    args = parse_args()
+    dataset = load_dataset(args.dataset)
+    baseline_map = load_baseline(dataset.entries, args.baseline)
+
+    with freeze_datetime(dataset.frozen_at):
+        results = score_articles(dataset.entries, baseline_map)
+
+    positive_lookup = {
+        article_id: bool(payload.get("should_include"))
+        for article_id, payload in baseline_map.items()
+    }
+
+    print("=== Score Delta Summary ===")
+    ranked_by_delta = sorted(
+        [
+            item
+            for item in results
+            if item.score_delta is not None and item.baseline_should_include is not None
+        ],
+        key=lambda x: abs(x.score_delta or 0.0),
+        reverse=True,
+    )
+
+    if ranked_by_delta:
+        print(f"Top {min(args.report_top, len(ranked_by_delta))} absolute score changes:")
+        for item in ranked_by_delta[: args.report_top]:
+            baseline_flag = "Y" if item.baseline_should_include else "N"
+            current_flag = "Y" if item.should_include else "N"
+            delta = item.score_delta or 0.0
+            print(
+                f"  - {item.article_id}: Δscore={delta:+.4f} | baseline_included={baseline_flag} | current_included={current_flag}"
+            )
+    else:
+        print("No baseline values found in dataset; skipping delta table.")
+
+    unique_k = sorted(set(k for k in args.top_k if isinstance(k, int) and k > 0))
+    if not unique_k:
+        unique_k = [5]
+
+    print("\nPrecision against baseline inclusions:")
+    for k in unique_k:
+        precision = precision_at_k(results, positive_lookup, k)
+        print(f"  Precision@{k}: {precision:.3f}")
+
+    coverage = compute_coverage(results, positive_lookup)
+    print(f"\nBaseline coverage by current scorer: {coverage:.3f}")
+
+    missing_baseline = [item.article_id for item in results if item.article_id not in baseline_map]
+    if missing_baseline:
+        print("\nWarning: baseline scores missing for the following articles:")
+        for article_id in missing_baseline:
+            print(f"  - {article_id}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/data/scoring_golden.json
+++ b/tests/data/scoring_golden.json
@@ -1,0 +1,255 @@
+{
+  "frozen_at": "2025-01-15T12:00:00Z",
+  "articles": [
+    {
+      "id": "astro-lab-breakthrough",
+      "article": {
+        "id": "astro-lab-breakthrough",
+        "title": "New Chilean astro lab reveals cosmic ray patterns",
+        "summary": "Researchers in Santiago publish detailed measurements of cosmic rays with AI assistance.",
+        "published_date": "2025-01-15T09:45:00+00:00",
+        "word_count": 920,
+        "duplication_confidence": 0.05,
+        "article_metadata": {
+          "source_metadata": {
+            "credibility_score": 0.92
+          },
+          "normalized_title": "new chilean astro lab reveals cosmic ray patterns",
+          "normalized_summary": "researchers in santiago publish detailed measurements of cosmic rays with ai assistance",
+          "enrichment": {
+            "entities": [
+              {
+                "text": "Santiago",
+                "type": "LOC"
+              },
+              {
+                "text": "cosmic rays",
+                "type": "SCI"
+              },
+              {
+                "text": "AI",
+                "type": "TECH"
+              },
+              {
+                "text": "Chile",
+                "type": "LOC"
+              }
+            ],
+            "sentiment": "positive"
+          },
+          "engagement_features": {
+            "score": 0.82
+          }
+        }
+      },
+      "expected": {
+        "final_score": 0.7787343441345013,
+        "should_include": true,
+        "components": {
+          "source_credibility": 0.92,
+          "recency": 0.9170040432046712,
+          "content_quality": 0.4103333333333334,
+          "engagement": 0.8919999999999999,
+          "engagement_potential": null
+        },
+        "penalties": {
+          "diversity_penalty": 0.0075
+        },
+        "rank": 1
+      }
+    },
+    {
+      "id": "community-lab-upgrade",
+      "article": {
+        "id": "community-lab-upgrade",
+        "title": "Community lab upgrades shared microscopes",
+        "summary": "Volunteer technicians refurbish optics for public bio labs across Chile.",
+        "word_count": 520,
+        "duplication_confidence": 0.1,
+        "published_date": null,
+        "article_metadata": {
+          "credibility_score": 0.58,
+          "normalized_title": "community lab upgrades shared microscopes",
+          "normalized_summary": "volunteer technicians refurbish optics for public bio labs across chile",
+          "enrichment": {
+            "entities": [
+              {
+                "text": "Chile",
+                "type": "LOC"
+              },
+              {
+                "text": "bio labs",
+                "type": "ORG"
+              },
+              {
+                "text": "microscopes",
+                "type": "SCI"
+              }
+            ],
+            "sentiment": "positive"
+          }
+        }
+      },
+      "expected": {
+        "final_score": 0.5019166666666667,
+        "should_include": true,
+        "components": {
+          "source_credibility": 0.58,
+          "recency": 0.5,
+          "content_quality": 0.32766666666666666,
+          "engagement": 0.6799999999999999,
+          "engagement_potential": null
+        },
+        "penalties": {
+          "diversity_penalty": 0.015
+        },
+        "rank": 2
+      }
+    },
+    {
+      "id": "legacy-observatory-archive",
+      "article": {
+        "id": "legacy-observatory-archive",
+        "title": "Legacy observatory releases 20-year archive",
+        "summary": "Digitized sky survey unlocks star catalogs for citizen scientists.",
+        "published_date": "2024-12-20T11:00:00+00:00",
+        "word_count": 480,
+        "duplication_confidence": 0.0,
+        "article_metadata": {
+          "source_metadata": {
+            "credibility_score": 0.88
+          },
+          "normalized_title": "legacy observatory releases 20 year archive",
+          "normalized_summary": "digitized sky survey unlocks star catalogs for citizen scientists",
+          "enrichment": {
+            "entities": [
+              {
+                "text": "observatory",
+                "type": "ORG"
+              },
+              {
+                "text": "sky survey",
+                "type": "SCI"
+              }
+            ],
+            "sentiment": "positive"
+          }
+        }
+      },
+      "expected": {
+        "final_score": 0.4680833333333333,
+        "should_include": true,
+        "components": {
+          "source_credibility": 0.88,
+          "recency": 0.0,
+          "content_quality": 0.28833333333333333,
+          "engagement": 0.6599999999999999,
+          "engagement_potential": null
+        },
+        "penalties": {
+          "diversity_penalty": 0.0
+        },
+        "rank": 3
+      }
+    },
+    {
+      "id": "andes-climate-model",
+      "article": {
+        "id": "andes-climate-model",
+        "title": "Open-source climate model captures Andes microclimates",
+        "summary": "University consortium validates new climate simulations comparing Andean glaciers and rainfall.",
+        "published_date": "2025-01-13T07:30:00+00:00",
+        "word_count": 640,
+        "duplication_confidence": 0.2,
+        "article_metadata": {
+          "source_metadata": {
+            "credibility_score": 0.74
+          },
+          "normalized_title": "open source climate model captures andes microclimates",
+          "normalized_summary": "university consortium validates new climate simulations comparing andean glaciers and rainfall",
+          "enrichment": {
+            "entities": [
+              {
+                "text": "Andes",
+                "type": "LOC"
+              },
+              {
+                "text": "glaciers",
+                "type": "SCI"
+              },
+              {
+                "text": "rainfall",
+                "type": "SCI"
+              }
+            ],
+            "sentiment": "neutral"
+          }
+        }
+      },
+      "expected": {
+        "final_score": 0.44760822169872805,
+        "should_include": true,
+        "components": {
+          "source_credibility": 0.74,
+          "recency": 0.13243288679491189,
+          "content_quality": 0.394,
+          "engagement": 0.6200000000000001,
+          "engagement_potential": null
+        },
+        "penalties": {
+          "diversity_penalty": 0.03
+        },
+        "rank": 4
+      }
+    },
+    {
+      "id": "duplicate-research-note",
+      "article": {
+        "id": "duplicate-research-note",
+        "title": "Research note mirrors previous AI ethics finding",
+        "summary": "Short communication reiterates community guidelines on AI transparency.",
+        "published_date": "2025-01-12T20:00:00+00:00",
+        "word_count": 350,
+        "duplication_confidence": 0.85,
+        "article_metadata": {
+          "source_metadata": {
+            "credibility_score": 0.66
+          },
+          "normalized_title": "research note mirrors previous ai ethics finding",
+          "normalized_summary": "short communication reiterates community guidelines on ai transparency",
+          "enrichment": {
+            "entities": [
+              {
+                "text": "AI",
+                "type": "TECH"
+              },
+              {
+                "text": "ethics",
+                "type": "THEME"
+              }
+            ],
+            "sentiment": "neutral"
+          },
+          "engagement_features": {
+            "score": 0.45
+          }
+        }
+      },
+      "expected": {
+        "final_score": 0.25826234375272467,
+        "should_include": false,
+        "components": {
+          "source_credibility": 0.66,
+          "recency": 0.08504937501089856,
+          "content_quality": 0.31000000000000005,
+          "engagement": 0.44500000000000006,
+          "engagement_potential": null
+        },
+        "penalties": {
+          "diversity_penalty": 0.1275
+        },
+        "rank": 5
+      }
+    }
+  ]
+}

--- a/tests/test_scoring_golden.py
+++ b/tests/test_scoring_golden.py
@@ -1,0 +1,78 @@
+"""Golden regression tests for the feature-based scorer."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Dict
+
+import pytest
+
+from src.scoring import feature_scorer
+from src.scoring.feature_scorer import FeatureBasedScorer
+
+DATA_PATH = Path(__file__).resolve().parent / "data" / "scoring_golden.json"
+ABS_TOL = 1e-6
+
+
+def _load_dataset() -> Dict[str, Any]:
+    with DATA_PATH.open(encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def _to_article_namespace(payload: Dict[str, Any]) -> SimpleNamespace:
+    article_payload = dict(payload)
+    article_payload.setdefault("article_metadata", {})
+    return SimpleNamespace(**article_payload)
+
+
+class _FrozenDateTime(datetime):
+    """Helper used to freeze `datetime.now` inside the scorer module."""
+
+    frozen_value: datetime = datetime.now()
+
+    @classmethod
+    def now(cls, tz=None):  # type: ignore[override]
+        if tz:
+            return cls.frozen_value.astimezone(tz)
+        return cls.frozen_value
+
+
+@pytest.mark.parametrize("component", [
+    "source_credibility",
+    "recency",
+    "content_quality",
+    "engagement",
+])
+def test_scoring_components_match_golden(monkeypatch: pytest.MonkeyPatch, component: str) -> None:
+    golden_data = _load_dataset()
+    frozen_at = datetime.fromisoformat(golden_data["frozen_at"].replace("Z", "+00:00"))
+    _FrozenDateTime.frozen_value = frozen_at
+    monkeypatch.setattr(feature_scorer, "datetime", _FrozenDateTime)
+
+    scorer = FeatureBasedScorer()
+    scored_entries = []
+
+    for entry in golden_data["articles"]:
+        article_obj = _to_article_namespace(entry["article"])
+        score = scorer.score_article(article_obj)
+
+        expected = entry["expected"]
+        assert score["should_include"] == expected["should_include"]
+        assert score["final_score"] == pytest.approx(expected["final_score"], abs=ABS_TOL)
+        assert score["components"][component] == pytest.approx(
+            expected["components"][component], abs=ABS_TOL
+        )
+        assert score["penalties"]["diversity_penalty"] == pytest.approx(
+            expected["penalties"]["diversity_penalty"], abs=ABS_TOL
+        )
+
+        scored_entries.append({"id": entry["id"], "score": score["final_score"]})
+
+    ranked = sorted(scored_entries, key=lambda item: item["score"], reverse=True)
+    actual_ranks = {item["id"]: idx + 1 for idx, item in enumerate(ranked)}
+
+    for entry in golden_data["articles"]:
+        assert actual_ranks[entry["id"]] == entry["expected"]["rank"]


### PR DESCRIPTION
## Summary
- add a curated scoring golden dataset covering multiple sources and freshness scenarios
- add a regression test that validates FeatureBasedScorer components against the golden expectations
- add a score_delta CLI to compare current scores vs. a baseline and document the refresh workflow in CONTRIBUTING

## Testing
- PYTHONPATH=$PWD pytest tests/test_scoring_golden.py -q
- python scripts/score_delta.py --dataset tests/data/scoring_golden.json --top-k 3 --top-k 5


------
https://chatgpt.com/codex/tasks/task_e_68dc5bf0197c832f82a8fe2630a5b983