### PR TITLE
feat: parameterize scoring heuristics

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,23 @@ FRESHNESS_MAX_DECAY_HOURS=168
 DIVERSITY_PENALTY_WEIGHT=0.15
 DIVERSITY_MAX_PENALTY=0.3
 
+# Heurísticas de calidad de contenido
+SCORING_TITLE_LENGTH_DIVISOR=120
+SCORING_SUMMARY_LENGTH_DIVISOR=400
+SCORING_ENTITY_TARGET_COUNT=5
+SCORING_CONTENT_WEIGHT_TITLE=0.4
+SCORING_CONTENT_WEIGHT_SUMMARY=0.4
+SCORING_CONTENT_WEIGHT_ENTITY=0.2
+
+# Heurísticas de engagement
+SCORING_SENTIMENT_POSITIVE=0.7
+SCORING_SENTIMENT_NEUTRAL=0.5
+SCORING_SENTIMENT_NEGATIVE=0.6
+SCORING_SENTIMENT_FALLBACK=0.5
+SCORING_WORD_COUNT_DIVISOR=800
+SCORING_ENGAGEMENT_EXTERNAL_WEIGHT=0.6
+SCORING_ENGAGEMENT_LENGTH_WEIGHT=0.4
+
 # Concurrencia de scoring
 SCORING_WORKERS=4
 
@@ -255,6 +272,16 @@ FEATURE_WEIGHT_ENGAGEMENT=0.10
 ```
 
 ¿Necesitas volver al algoritmo previo? Configura `SCORING_MODE=basic`.
+
+### Ajustar heurísticas sin romper el scoring
+
+El modo *advanced* expone controles finos para ajustar la sensibilidad del algoritmo sin introducir efectos secundarios inesperados:
+
+- **Divisores de longitud (`SCORING_TITLE_LENGTH_DIVISOR`, `SCORING_SUMMARY_LENGTH_DIVISOR`, `SCORING_WORD_COUNT_DIVISOR`)**: definen cuántos caracteres/palabras consideramos "suficientes" antes de dar puntuación máxima. Útiles para adaptar el sistema a resúmenes más cortos o notas largas.
+- **Peso de entidades (`SCORING_ENTITY_TARGET_COUNT`, `SCORING_CONTENT_WEIGHT_*`)**: controla cuánta relevancia damos a artículos con entidades enriquecidas. Mantén la suma de los pesos en `1.0` para conservar una escala estable.
+- **Sentimiento y engagement (`SCORING_SENTIMENT_*`, `SCORING_ENGAGEMENT_*`)**: permite reforzar o suavizar la señal emocional del contenido. Todos los valores se validan para permanecer en el rango `[0, 1]` y los pesos deben sumar `1.0` para evitar sesgos.
+
+El scorer valida estos parámetros al arrancar y levantará un `ValueError` si detecta divisores no positivos, pesos fuera de rango o sumas incorrectas. Así evitamos despliegues con configuraciones inconsistentes.
 
 ---
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -85,6 +85,37 @@ SCORING_CONFIG = {
         "weight": float(os.getenv("DIVERSITY_PENALTY_WEIGHT", 0.15)),
         "max_penalty": float(os.getenv("DIVERSITY_MAX_PENALTY", 0.3)),
     },
+    "content_quality_heuristics": {
+        "title_length_divisor": float(
+            os.getenv("SCORING_TITLE_LENGTH_DIVISOR", 120.0)
+        ),
+        "summary_length_divisor": float(
+            os.getenv("SCORING_SUMMARY_LENGTH_DIVISOR", 400.0)
+        ),
+        "entity_target_count": float(
+            os.getenv("SCORING_ENTITY_TARGET_COUNT", 5.0)
+        ),
+        "weights": {
+            "title": float(os.getenv("SCORING_CONTENT_WEIGHT_TITLE", 0.4)),
+            "summary": float(os.getenv("SCORING_CONTENT_WEIGHT_SUMMARY", 0.4)),
+            "entity": float(os.getenv("SCORING_CONTENT_WEIGHT_ENTITY", 0.2)),
+        },
+    },
+    "engagement_heuristics": {
+        "sentiment_scores": {
+            "positive": float(os.getenv("SCORING_SENTIMENT_POSITIVE", 0.7)),
+            "negative": float(os.getenv("SCORING_SENTIMENT_NEGATIVE", 0.6)),
+            "neutral": float(os.getenv("SCORING_SENTIMENT_NEUTRAL", 0.5)),
+        },
+        "fallback_sentiment": float(os.getenv("SCORING_SENTIMENT_FALLBACK", 0.5)),
+        "word_count_divisor": float(os.getenv("SCORING_WORD_COUNT_DIVISOR", 800.0)),
+        "external_weight": float(
+            os.getenv("SCORING_ENGAGEMENT_EXTERNAL_WEIGHT", 0.6)
+        ),
+        "length_weight": float(
+            os.getenv("SCORING_ENGAGEMENT_LENGTH_WEIGHT", 0.4)
+        ),
+    },
     "reranker_seed": int(os.getenv("RERANKER_SEED", 1337)),
     "source_cap_percentage": float(os.getenv("SOURCE_CAP_PERCENTAGE", 0.5)),
     "topic_cap_percentage": float(os.getenv("TOPIC_CAP_PERCENTAGE", 0.6)),

--- a/tests/test_feature_scorer_config.py
+++ b/tests/test_feature_scorer_config.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import copy
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC_DIR = ROOT / "src"
+
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+from config.settings import SCORING_CONFIG
+from src.scoring.feature_scorer import FeatureBasedScorer
+
+
+def _article_factory(**overrides):
+    metadata_override = overrides.pop("article_metadata", {})
+    metadata = {
+        "normalized_title": "baseline science title",  # ~24 chars
+        "normalized_summary": "baseline science summary" * 5,
+        "enrichment": {"entities": [], "sentiment": "neutral"},
+        "source_metadata": {"credibility_score": 0.7},
+        "engagement_features": {},
+    }
+    metadata.update(metadata_override)
+
+    return SimpleNamespace(
+        id="test-article",
+        title="Science advances",
+        summary="Detailed overview of recent discoveries." * 3,
+        published_date=overrides.get(
+            "published_date", datetime(2025, 1, 1, tzinfo=timezone.utc)
+        ),
+        word_count=overrides.get("word_count", 400),
+        duplication_confidence=overrides.get("duplication_confidence", 0.0),
+        article_metadata=metadata,
+    )
+
+
+def test_content_quality_weights_respected() -> None:
+    config = copy.deepcopy(SCORING_CONFIG)
+    config["content_quality_heuristics"] = {
+        "title_length_divisor": 100.0,
+        "summary_length_divisor": 200.0,
+        "entity_target_count": 3.0,
+        "weights": {"title": 0.2, "summary": 0.3, "entity": 0.5},
+    }
+
+    article = _article_factory(
+        article_metadata={
+            "normalized_title": "t" * 80,
+            "normalized_summary": "s" * 300,
+            "enrichment": {"entities": [{}, {}, {}, {}], "sentiment": "neutral"},
+        }
+    )
+
+    scorer = FeatureBasedScorer(config)
+    result = scorer.score_article(article)
+
+    assert result["components"]["content_quality"] == pytest.approx(0.96, abs=1e-6)
+
+
+def test_engagement_heuristics_pull_from_config() -> None:
+    config = copy.deepcopy(SCORING_CONFIG)
+    config["engagement_heuristics"] = {
+        "sentiment_scores": {"positive": 0.9, "negative": 0.1, "neutral": 0.2},
+        "fallback_sentiment": 0.2,
+        "word_count_divisor": 1000.0,
+        "external_weight": 0.7,
+        "length_weight": 0.3,
+    }
+
+    article = _article_factory(
+        word_count=500,
+        article_metadata={
+            "enrichment": {"sentiment": "positive", "entities": []},
+        },
+    )
+
+    scorer = FeatureBasedScorer(config)
+    result = scorer.score_article(article)
+
+    expected_engagement = 0.7 * 0.9 + 0.3 * min(500 / 1000.0, 1.0)
+    assert result["components"]["engagement"] == pytest.approx(
+        expected_engagement, abs=1e-6
+    )
+
+
+def test_invalid_divisors_raise_value_error() -> None:
+    config = copy.deepcopy(SCORING_CONFIG)
+    config["content_quality_heuristics"] = {
+        "title_length_divisor": 0.0,
+        "summary_length_divisor": 200.0,
+        "entity_target_count": 5.0,
+        "weights": {"title": 0.4, "summary": 0.4, "entity": 0.2},
+    }
+
+    with pytest.raises(ValueError, match="title_length_divisor"):
+        FeatureBasedScorer(config)
+
+
+def test_diversity_penalty_remains_deterministic() -> None:
+    config = copy.deepcopy(SCORING_CONFIG)
+    config["diversity_penalty"] = {"weight": 0.5, "max_penalty": 1.0}
+
+    scorer = FeatureBasedScorer(config)
+    article = _article_factory(duplication_confidence=0.4)
+
+    result = scorer.score_article(article)
+
+    assert result["penalties"]["diversity_penalty"] == pytest.approx(0.2, abs=1e-6)

--- a/tests/test_scoring_golden.py
+++ b/tests/test_scoring_golden.py
@@ -3,12 +3,21 @@
 from __future__ import annotations
 
 import json
+import sys
 from datetime import datetime
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, Dict
 
 import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC_DIR = ROOT / "src"
+
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
 
 from src.scoring import feature_scorer
 from src.scoring.feature_scorer import FeatureBasedScorer


### PR DESCRIPTION
## Summary
- expose content quality, sentiment, and engagement heuristics through `SCORING_CONFIG`
- update the feature-based scorer to consume and validate the new configuration knobs
- document the new tuning parameters and cover them with regression tests

## Testing
- pytest tests/test_feature_scorer_config.py tests/test_scoring_golden.py


------
https://chatgpt.com/codex/tasks/task_e_68dc5de84f08832fbc05fc6e276a89a0