### PR TITLE
Add pipeline performance regression test and baselines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,13 @@ jobs:
         run: make e2e
       - name: Performance checks
         run: make perf
+      - name: Upload performance logs
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: pipeline-perf-logs
+          path: reports/perf
+          if-no-files-found: warn
       - name: Security checks
         id: security
         continue-on-error: true

--- a/config/perf_thresholds.py
+++ b/config/perf_thresholds.py
@@ -1,0 +1,20 @@
+"""Performance baseline thresholds for regression checks."""
+
+from __future__ import annotations
+
+PIPELINE_PERF_THRESHOLDS: dict[str, dict[str, float]] = {
+    "ingestion": {
+        "p95_seconds": 0.35,
+        "max_seconds": 0.45,
+    },
+    "enrichment": {
+        "p95_seconds": 0.20,
+        "max_seconds": 0.30,
+    },
+    "scoring": {
+        "p95_seconds": 0.15,
+        "max_seconds": 0.25,
+    },
+}
+
+__all__ = ["PIPELINE_PERF_THRESHOLDS"]

--- a/docs/performance_baselines.md
+++ b/docs/performance_baselines.md
@@ -1,0 +1,36 @@
+# Pipeline Performance Baselines
+
+The performance regression suite enforces latency thresholds for the offline pipeline
+(using the same fixtures we rely on for end-to-end validation). These baselines are
+codified in `config/perf_thresholds.py` and exercised by the pytest module in
+`tests/perf/test_pipeline_perf.py`.
+
+## When the perf test fails
+
+A failure means one of the measured stages (ingestion, enrichment, or scoring)
+exceeded either the configured P95 or max duration. Investigate the perf log produced
+at `reports/perf/pipeline_perf_metrics.json` (uploaded in CI as an artifact) to identify
+which stage regressed.
+
+## Refreshing baselines after intentional optimizations
+
+When you intentionally optimize part of the pipeline and want to bake the new timing
+into the guardrail:
+
+1. Run the profiling helper to capture reference numbers:
+   ```bash
+   python scripts/profile_pipeline.py > profiling.log
+   ```
+2. Review the log and identify the steady-state timings for ingestion, enrichment, and
+   scoring. Focus on representative runs (`optimized-advanced` scenario is our
+   reference).
+3. Update the values in `config/perf_thresholds.py` to reflect the new P95/max targets.
+   Keep headroom (≈10-15%) to avoid flakiness.
+4. Execute the perf test locally to verify it passes:
+   ```bash
+   pytest tests/perf/test_pipeline_perf.py
+   ```
+5. Commit the refreshed thresholds together with a summary of the profiling results in
+   your PR description.
+
+This workflow ensures we lock in improvements while catching accidental slowdowns.

--- a/tests/perf/test_pipeline_perf.py
+++ b/tests/perf/test_pipeline_perf.py
@@ -1,0 +1,178 @@
+"""Performance regression tests for the offline pipeline path."""
+
+from __future__ import annotations
+
+import json
+import math
+import statistics
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from time import perf_counter
+from typing import Dict, List
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT.parent) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT.parent))
+
+from config.perf_thresholds import PIPELINE_PERF_THRESHOLDS
+from src.collectors import RSSCollector
+from src.enrichment import enrichment_pipeline
+from src.scoring import create_scorer
+from src.storage import models as storage_models
+from src.storage.database import DatabaseManager
+
+FIXTURE_PATH = PROJECT_ROOT / "data" / "collector_pipeline_chain.json"
+
+pytestmark = pytest.mark.perf
+
+
+def _percentile(values: List[float], percentile: float) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    if len(ordered) == 1:
+        return ordered[0]
+    rank = percentile * (len(ordered) - 1)
+    lower = math.floor(rank)
+    upper = math.ceil(rank)
+    if lower == upper:
+        return ordered[int(rank)]
+    weight = rank - lower
+    return ordered[lower] + (ordered[upper] - ordered[lower]) * weight
+
+
+def _prepare_raw_article(entry: Dict[str, object]) -> Dict[str, object]:
+    collector_raw = dict(entry["collector_raw"])
+    offset_hours = float(collector_raw.pop("published_offset_hours"))
+    published_ts = datetime.now(timezone.utc) + timedelta(hours=offset_hours)
+    collector_raw["published_date"] = published_ts
+    collector_raw.setdefault("published_tz_offset_minutes", 0)
+    collector_raw.setdefault("published_tz_name", "UTC")
+    collector_raw.setdefault("original_url", collector_raw["url"])
+    collector_raw.setdefault("source_metadata", {})
+    return collector_raw
+
+
+@pytest.fixture(scope="module")
+def pipeline_dataset() -> List[Dict[str, object]]:
+    with FIXTURE_PATH.open(encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+@pytest.fixture()
+def isolated_database(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> DatabaseManager:
+    db_path = tmp_path / "perf_pipeline.db"
+    manager = DatabaseManager({"type": "sqlite", "path": db_path})
+
+    import src.storage.database as database_module
+
+    monkeypatch.setattr(database_module, "_db_manager", manager, raising=False)
+    monkeypatch.setattr("src.collectors.rss_collector.get_database_manager", lambda: manager)
+
+    return manager
+
+
+@pytest.fixture()
+def collector(monkeypatch: pytest.MonkeyPatch, isolated_database: DatabaseManager) -> RSSCollector:
+    collector = RSSCollector()
+
+    monkeypatch.setattr(RSSCollector, "_respect_robots", lambda self, url: (True, None))
+    monkeypatch.setattr(
+        RSSCollector,
+        "_enforce_domain_rate_limit",
+        lambda self, domain, robots_delay, source_min_delay=None: None,
+    )
+    monkeypatch.setattr(
+        RSSCollector, "_fetch_feed", lambda self, source_id, feed_url: ("<rss/>", 200)
+    )
+
+    dummy_feed = type("DummyFeed", (), {"bozo": 0})()
+    monkeypatch.setattr("feedparser.parse", lambda content: dummy_feed)
+
+    def fake_extract(self, parsed_feed, source_config):
+        return getattr(self, "_test_articles", [])
+
+    monkeypatch.setattr(RSSCollector, "_extract_articles_from_feed", fake_extract)
+
+    return collector
+
+
+def test_pipeline_stage_latencies(
+    collector: RSSCollector,
+    pipeline_dataset: List[Dict[str, object]],
+    isolated_database: DatabaseManager,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stage_timings: Dict[str, List[float]] = {"ingestion": [], "enrichment": [], "scoring": []}
+
+    original_enrich = enrichment_pipeline.enrich_article
+
+    def timed_enrich(article: Dict[str, object] | object) -> Dict[str, object]:
+        start = perf_counter()
+        result = original_enrich(article)
+        stage_timings["enrichment"].append(perf_counter() - start)
+        return result
+
+    monkeypatch.setattr(enrichment_pipeline, "enrich_article", timed_enrich)
+
+    scorer = create_scorer()
+
+    for entry in pipeline_dataset:
+        raw_article = _prepare_raw_article(entry)
+        collector._test_articles = [raw_article]
+
+        source = entry["source"]
+        source_config = {
+            "name": source["name"],
+            "url": source["url"],
+            "category": source["category"],
+            "credibility_score": source["credibility_score"],
+            "language": source.get("language", "en"),
+        }
+
+        ingest_start = perf_counter()
+        stats = collector.collect_from_source(source["id"], source_config)
+        stage_timings["ingestion"].append(perf_counter() - ingest_start)
+        assert stats["success"] is True
+
+        with isolated_database.get_session() as session:
+            stored_article = (
+                session.query(storage_models.Article)
+                .filter_by(url=raw_article["url"])
+                .first()
+            )
+        assert stored_article is not None
+
+        score_start = perf_counter()
+        scorer.score_article(stored_article)
+        stage_timings["scoring"].append(perf_counter() - score_start)
+
+    metrics: Dict[str, Dict[str, float]] = {}
+    for stage, durations in stage_timings.items():
+        assert durations, f"No samples recorded for {stage} stage"
+        metrics[stage] = {
+            "samples": len(durations),
+            "mean_seconds": statistics.fmean(durations),
+            "p95_seconds": _percentile(durations, 0.95),
+            "max_seconds": max(durations),
+        }
+
+    for stage, thresholds in PIPELINE_PERF_THRESHOLDS.items():
+        stage_metrics = metrics[stage]
+        assert (
+            stage_metrics["p95_seconds"] <= thresholds["p95_seconds"]
+        ), f"{stage} p95 exceeded: {stage_metrics['p95_seconds']:.4f}s > {thresholds['p95_seconds']:.4f}s"
+        assert (
+            stage_metrics["max_seconds"] <= thresholds["max_seconds"]
+        ), f"{stage} max exceeded: {stage_metrics['max_seconds']:.4f}s > {thresholds['max_seconds']:.4f}s"
+
+    perf_reports_dir = PROJECT_ROOT.parent / "reports" / "perf"
+    perf_reports_dir.mkdir(parents=True, exist_ok=True)
+    log_path = perf_reports_dir / "pipeline_perf_metrics.json"
+    with log_path.open("w", encoding="utf-8") as fh:
+        json.dump({"metrics": metrics, "thresholds": PIPELINE_PERF_THRESHOLDS}, fh, indent=2)
+
+    print(f"pipeline_perf_log={log_path}")


### PR DESCRIPTION
## Summary
- add configuration module with pipeline performance thresholds derived from profiling
- implement offline pytest perf regression for ingestion/enrichment/scoring and write metrics artifact
- update CI to publish perf logs and document how to refresh baselines

## Testing
- pytest tests/perf/test_pipeline_perf.py

------
https://chatgpt.com/codex/tasks/task_e_68dc5fc5f2c0832f8d169428647c211b