### PR TITLE
Add structured logging telemetry for collector runs

### DIFF
--- a/docs/collector_runbook.md
+++ b/docs/collector_runbook.md
@@ -44,3 +44,51 @@ The RSS collector fetches scientific feeds on a fixed cadence, applies polite ra
 1. Run `pytest tests/test_rate_limit_and_backoff.py -k conditional` to ensure regression coverage for cached headers.
 2. Trigger a dry run (`python run_collector.py --dry-run --sources nature`) and confirm logs show the conditional request headers.
 3. Review Grafana panels for fetch duration and response codes to verify fewer bytes transferred after deploying caching.
+
+## Structured Logging Reference
+- Every collector cycle emits structured log dictionaries. Core fields:
+  - `trace_id`: stable per cycle; follows the CLI trace id when triggered via `run_collector.py`.
+  - `session_id`: human-readable session handle (e.g. `abc123-20250203-153045`).
+  - `source_id`: collector source or logical module (`system`, `cli`).
+  - `latency`: seconds spent in the operation.
+- Sample entries:
+  ```json
+  {
+    "event": "collection_cycle.start",
+    "trace_id": "a0c7e4f1-2cbe-4d97-9baf-ef5a1b4d8e2c",
+    "session_id": "0fb12c-20250203-153045",
+    "source_id": "system",
+    "latency": 0.0,
+    "details": {"dry_run": false, "source_filter": "all"}
+  }
+  {
+    "event": "collector.source.failed",
+    "trace_id": "a0c7e4f1-2cbe-4d97-9baf-ef5a1b4d8e2c",
+    "session_id": "0fb12c-20250203-153045",
+    "source_id": "esa",
+    "latency": 2.41,
+    "details": {"articles_found": 0, "articles_saved": 0, "error_message": "timeout"}
+  }
+  {
+    "event": "cli.collection.completed",
+    "trace_id": "a0c7e4f1-2cbe-4d97-9baf-ef5a1b4d8e2c",
+    "session_id": "0fb12c-20250203-153045",
+    "source_id": "cli",
+    "latency": 186.2,
+    "details": {"sources_processed": 42, "articles_saved": 118}
+  }
+  ```
+
+## Troubleshooting Flow
+
+### Collector Failure
+1. Locate the corresponding `collector.source.failed` log entry using the `trace_id` from the CLI or scheduler trigger.
+2. Inspect `details.error_message`; retry transient network errors, but investigate rate limits or credential drift for persistent failures.
+3. Check metrics: `collector.ingest.error` tagged with the same `trace_id` and `source_id` confirms the error was emitted to telemetry.
+4. If repeated failures occur, pause the source in `config/sources.py` and notify content owners; document mitigation in the ops log.
+
+### Scoring Error
+1. Search for `collection_cycle.error` events; they include the serialized exception under `details.error` with the active `trace_id`.
+2. Use `session_id` to pull staging articles for the problematic run from the database (`SELECT * FROM scored_articles WHERE session_id=?`).
+3. Run `pytest tests/test_scoring_pipeline.py -k <feature>` to reproduce locally. The metrics reporter will emit `collector.ingest.count` entries up to the failure point—confirm no duplicate scoring attempts afterward.
+4. Apply fixes, re-run the collector in dry-run mode, and verify `collection_cycle.completed` appears with a non-zero latency and expected article counts before redeploying.

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -11,7 +11,7 @@ from .collectors import RSSCollector, BaseCollector
 from .scoring import BasicScorer, score_multiple_articles
 from .storage import get_database_manager, DatabaseManager
 from .serving import create_app
-from .utils import get_logger, setup_logging
+from .utils import get_logger, setup_logging, get_metrics_reporter
 
 __version__ = "1.0.0"
 __description__ = (
@@ -36,5 +36,6 @@ __all__ = [
     "DatabaseManager",
     "get_logger",
     "setup_logging",
+    "get_metrics_reporter",
     "create_app",
 ]

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -3,8 +3,12 @@ Utilidades del News Collector System.
 """
 
 from .logger import get_logger, setup_logging
+from .metrics import get_metrics_reporter, MetricsReporter, MetricEvent
 
 __all__ = [
     "get_logger",
     "setup_logging",
+    "get_metrics_reporter",
+    "MetricsReporter",
+    "MetricEvent",
 ]

--- a/src/utils/metrics.py
+++ b/src/utils/metrics.py
@@ -1,0 +1,97 @@
+"""Lightweight metrics reporting utilities for the News Collector.
+
+This module intentionally keeps the implementation minimal so that unit tests
+can validate that we emit the right telemetry events without requiring a real
+StatsD or OpenTelemetry backend. The API mimics a subset of common metrics
+client interfaces and stores emitted events in memory for observability.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from threading import Lock
+from typing import Any, Dict, List, Optional
+
+
+@dataclass(frozen=True)
+class MetricEvent:
+    """Represents a single metric emission."""
+
+    name: str
+    value: float
+    attributes: Dict[str, Any]
+
+
+class MetricsReporter:
+    """Simple in-process metrics reporter used during development and tests."""
+
+    def __init__(self) -> None:
+        self._lock = Lock()
+        self._events: List[MetricEvent] = []
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def record_ingest(
+        self,
+        *,
+        source_id: str,
+        article_count: int,
+        latency: float,
+        trace_id: str,
+        session_id: str,
+    ) -> None:
+        """Emit counter and latency metrics for a successful ingest."""
+
+        attributes = {
+            "source_id": source_id,
+            "trace_id": trace_id,
+            "session_id": session_id,
+        }
+        self._emit("collector.ingest.count", article_count, attributes)
+        self._emit("collector.ingest.latency", latency, attributes)
+
+    def record_error(
+        self,
+        *,
+        source_id: str,
+        error: str,
+        trace_id: str,
+        session_id: str,
+    ) -> None:
+        """Emit an error counter for collector failures."""
+
+        attributes = {
+            "source_id": source_id,
+            "trace_id": trace_id,
+            "session_id": session_id,
+            "error": error,
+        }
+        self._emit("collector.ingest.error", 1, attributes)
+
+    def snapshot(self) -> List[MetricEvent]:
+        """Return a copy of the emitted events for inspection."""
+
+        with self._lock:
+            return list(self._events)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _emit(self, name: str, value: float, attributes: Optional[Dict[str, Any]] = None) -> None:
+        event = MetricEvent(name=name, value=value, attributes=attributes or {})
+        with self._lock:
+            self._events.append(event)
+
+
+_metrics_reporter: Optional[MetricsReporter] = None
+
+
+def get_metrics_reporter() -> MetricsReporter:
+    """Return a process-wide singleton metrics reporter."""
+
+    global _metrics_reporter
+    if _metrics_reporter is None:
+        _metrics_reporter = MetricsReporter()
+    return _metrics_reporter
+

--- a/tests/test_main_initialization.py
+++ b/tests/test_main_initialization.py
@@ -154,8 +154,17 @@ def test_initialize_with_failed_sources_warning(monkeypatch):
 
     database_logger = dummy_logger.modules.get("database")
     assert database_logger is not None
-    assert any("fuentes" in msg.lower() for msg in database_logger.warnings)
+    assert any(
+        isinstance(event, dict)
+        and event.get("event") == "database.health.warning"
+        and event.get("details", {}).get("failed_sources") == 1
+        for event in database_logger.warnings
+    )
 
     system_logger = dummy_logger.modules.get("system")
     assert system_logger is not None
-    assert any("advertencias" in msg.lower() for msg in system_logger.warnings)
+    assert any(
+        isinstance(event, dict)
+        and event.get("event") == "system.initialize.warning"
+        for event in system_logger.warnings
+    )

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -1,0 +1,217 @@
+"""Observability focused tests for structured logging and metrics."""
+
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Dict
+
+import pytest
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+import main
+
+
+class StructuredModuleLogger:
+    """Proxy logger that forwards messages to the stdlib logging module."""
+
+    def __init__(self, module_name: str) -> None:
+        self._logger = logging.getLogger(f"test.{module_name}")
+
+    def info(self, message: Any) -> None:  # pragma: no cover - trivial proxy
+        self._logger.info(message)
+
+    def warning(self, message: Any) -> None:  # pragma: no cover - trivial proxy
+        self._logger.warning(message)
+
+    def error(self, message: Any) -> None:  # pragma: no cover - trivial proxy
+        self._logger.error(message)
+
+
+class StubLoggerFactory:
+    """Minimal logger factory compatible with the NewsCollectorSystem."""
+
+    def __init__(self) -> None:
+        self.modules: Dict[str, StructuredModuleLogger] = {}
+
+    def create_module_logger(self, module_name: str) -> StructuredModuleLogger:
+        if module_name not in self.modules:
+            self.modules[module_name] = StructuredModuleLogger(module_name)
+        return self.modules[module_name]
+
+    def log_performance_metrics(self, metrics: Dict[str, Any], context: str = "") -> None:
+        logging.getLogger("test.performance").info({"metrics": metrics, "context": context})
+
+    def log_error_with_context(self, error: Exception, context: Dict[str, Any] | None = None) -> None:
+        logging.getLogger("test.errors").error({"error": str(error), "context": context})
+
+    def log_system_startup(self, **_kwargs: Any) -> None:  # pragma: no cover - stub
+        return None
+
+    def log_system_health(self) -> None:  # pragma: no cover - stub
+        return None
+
+
+class StubMetrics:
+    """Captures metric events for assertions."""
+
+    def __init__(self) -> None:
+        self.ingest_events = []
+        self.error_events = []
+
+    def record_ingest(self, **payload: Any) -> None:
+        self.ingest_events.append(payload)
+
+    def record_error(self, **payload: Any) -> None:
+        self.error_events.append(payload)
+
+
+def test_collection_cycle_logs_and_emits_metrics(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+    """run_collection_cycle should emit structured logs and metrics per source."""
+
+    caplog.set_level(logging.INFO)
+
+    logger_factory = StubLoggerFactory()
+    metrics_stub = StubMetrics()
+
+    system = main.NewsCollectorSystem()
+    system.logger = logger_factory
+    system.system_logger = logger_factory.create_module_logger("system")
+    system.metrics = metrics_stub
+    system.is_initialized = True
+
+    collection_results = {
+        "collection_summary": {
+            "sources_processed": 2,
+            "articles_found": 4,
+            "articles_saved": 2,
+            "success_rate_percent": 50,
+        },
+        "source_details": {
+            "source_a": {
+                "success": True,
+                "articles_found": 3,
+                "articles_saved": 2,
+                "processing_time": 1.25,
+            },
+            "source_b": {
+                "success": False,
+                "articles_found": 1,
+                "articles_saved": 0,
+                "processing_time": 0.5,
+                "error_message": "timeout",
+            },
+        },
+    }
+
+    scoring_results = {"statistics": {"articles_scored": 2}}
+    final_selection = {"success": True, "selected_count": 1, "articles": []}
+    final_summary = {
+        "summary": {
+            "sources_processed": 2,
+            "articles_found": 4,
+            "articles_saved": 2,
+            "articles_scored": 2,
+            "final_selection_count": 1,
+        },
+        "performance_metrics": {
+            "total_duration_seconds": 1.0,
+            "articles_per_second": 4.0,
+            "sources_per_minute": 2.0,
+            "success_rate_percent": 50,
+        },
+        "session_info": {
+            "session_id": "dummy-session",
+            "system_id": system.system_id,
+            "start_time": system.start_time.isoformat(),
+            "end_time": system.start_time.isoformat(),
+            "duration_seconds": 1.0,
+        },
+    }
+
+    monkeypatch.setattr(
+        main.NewsCollectorSystem,
+        "_get_sources_to_process",
+        lambda self, _sources_filter: {"source_a": {}, "source_b": {}},
+    )
+    monkeypatch.setattr(
+        main.NewsCollectorSystem,
+        "_execute_collection",
+        lambda self, _sources, _dry_run: collection_results,
+    )
+    monkeypatch.setattr(
+        main.NewsCollectorSystem,
+        "_execute_scoring",
+        lambda self, _collection_results, _dry_run: scoring_results,
+    )
+    monkeypatch.setattr(
+        main.NewsCollectorSystem,
+        "_execute_final_selection",
+        lambda self, _scoring_results: final_selection,
+    )
+    monkeypatch.setattr(
+        main.NewsCollectorSystem,
+        "_generate_session_report",
+        lambda self, *_args, **_kwargs: final_summary,
+    )
+
+    result = system.run_collection_cycle(trace_id="test-trace")
+
+    assert result["summary"]["articles_saved"] == 2
+    assert len(metrics_stub.ingest_events) == 1
+    assert metrics_stub.ingest_events[0]["source_id"] == "source_a"
+    assert metrics_stub.ingest_events[0]["trace_id"] == "test-trace"
+
+    assert len(metrics_stub.error_events) == 1
+    assert metrics_stub.error_events[0]["source_id"] == "source_b"
+
+    structured_messages = [record.msg for record in caplog.records if isinstance(record.msg, dict)]
+    assert any(
+        msg.get("event") == "collector.source.completed" and msg.get("source_id") == "source_a"
+        for msg in structured_messages
+    )
+    assert any(
+        msg.get("event") == "collector.source.failed" and msg.get("source_id") == "source_b"
+        for msg in structured_messages
+    )
+
+
+def test_cli_logging(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+    """run_simple_collection should log lifecycle events via the module logger."""
+
+    from run_collector import run_simple_collection
+
+    caplog.set_level(logging.INFO)
+
+    logger_factory = StubLoggerFactory()
+    monkeypatch.setattr("run_collector.setup_logging", lambda: logger_factory)
+
+    class DummySystem:
+        def initialize(self) -> bool:
+            return True
+
+        def run_collection_cycle(self, **_kwargs: Any) -> Dict[str, Any]:
+            return {
+                "session_info": {"session_id": "cli-session"},
+                "summary": {"sources_processed": 1},
+            }
+
+    monkeypatch.setattr("run_collector.create_system", lambda: DummySystem())
+
+    args = SimpleNamespace(
+        quiet=True,
+        sources=None,
+        dry_run=False,
+        show_articles=0,
+        verbose=False,
+    )
+
+    assert run_simple_collection(args) is True
+
+    structured_messages = [record.msg for record in caplog.records if isinstance(record.msg, dict)]
+    assert any(msg.get("event") == "cli.collection.completed" for msg in structured_messages)


### PR DESCRIPTION
## Summary
- refactor the NewsCollectorSystem lifecycle to emit structured module logs and per-source metrics events
- add a lightweight metrics reporter stub plus CLI logging to share trace ids with collector sessions
- cover the observability pipeline with new unit tests and expand the runbook with log samples and troubleshooting steps

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dc640b41c0832fbdfc0984a629d533