### PR TITLE
Add operational healthcheck and runbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,13 @@ python run_collector.py --list-sources
 python run_collector.py --check-deps
 ```
 
+### Healthcheck Operativo
+```bash
+python run_collector.py --healthcheck
+```
+- Verifica conectividad con la base de datos, backlog en la cola de artículos pendientes y la frescura de la última ingesta.
+- Consulta el runbook completo en [`docs/runbook.md`](docs/runbook.md) para flujos de diagnóstico y resolución cuando el healthcheck falle.
+
 ---
 
 ## 📚 Fuentes Configuradas

--- a/docs/collector_runbook.md
+++ b/docs/collector_runbook.md
@@ -1,7 +1,7 @@
 # 🛠️ Collector Runbook
 
 ## Overview
-The RSS collector fetches scientific feeds on a fixed cadence, applies polite rate limiting, and stores feed metadata for incremental polling. Operators can use this runbook to triage incidents and validate that caching is behaving as expected.
+The RSS collector fetches scientific feeds on a fixed cadence, applies polite rate limiting, and stores feed metadata for incremental polling. Operators can use this runbook to triage incidents and validate that caching is behaving as expected. For alerting workflows (ingest lag, dedupe drift, etc.) refer to the [Operations Runbook](runbook.md).
 
 ## Conditional Fetch Caching
 - We persist the latest `ETag` and `Last-Modified` headers per source in the `sources` table (`feed_etag`, `feed_last_modified`).

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -1,0 +1,83 @@
+# Operations Runbook
+
+This runbook documents the two paging alerts that matter most for the Noticiencias pipeline today. Each section explains what
+triggers the alert, how to triage it, and which tools to use when you are in the middle of an incident.
+
+## Alert Catalogue
+
+### 1. Ingest Lag Breach
+- **Signal**: Grafana alert `pipeline.ingest.lag_p95_minutes` (warning at 12 min, page at 18 min) or `python run_collector.py --healthcheck` returning a non-zero exit code.
+- **Impact**: Homepage stops showing newly published research; downstream enrichment and reranker backlogs accumulate.
+- **Primary owner**: Collector on-call.
+
+#### Diagnosis Workflow
+1. **Run the CLI healthcheck** to validate connectivity and queue depth without waiting on dashboards:
+   ```bash
+   python run_collector.py --healthcheck
+   ```
+   - Pending articles above the default threshold (250) or an ingest lag older than 180 minutes will fail the check.
+   - Override thresholds when debugging chronic backlogs: `python run_collector.py --healthcheck --healthcheck-max-pending 500`.
+2. **Inspect scheduler freshness**. Tail the structured logs for `collection_cycle.start`/`collection_cycle.completed` events and confirm cycles are still firing.
+   ```bash
+   sqlite3 data/news.db "SELECT MAX(collected_date) FROM articles;"
+   ```
+3. **Look for source specific failures** in the `sources` table. High `consecutive_failures` or stale `last_article_found` timestamps often indicate credential or robots.txt issues.
+   ```bash
+   sqlite3 data/news.db "SELECT id, last_article_found, consecutive_failures FROM sources ORDER BY consecutive_failures DESC LIMIT 10;"
+   ```
+4. **Check the DLQ** (`data/dlq/`). Files named `rss_<source>_*.json` represent payloads that failed to persist—open one to inspect the error context.
+
+#### Remediation Steps
+- **Transient network spikes**: re-run the collector in dry-run mode to confirm reachability.
+  ```bash
+  python run_collector.py --dry-run --sources nature mit_news
+  ```
+- **Rate limit throttling**: adjust `RATE_LIMITING_CONFIG["domain_overrides"]` or the per-source `min_delay_seconds` in `config/sources.py` and redeploy.
+- **Persistent parser failures**: replay the offending source through `scripts/replay_outage.py` with the fixture from `tests/data/monitoring/` to validate fixes before production.
+- **Database outage**: restart the managed SQLite/Postgres service and re-run `python run_collector.py --healthcheck` to verify the backlog clears.
+
+#### Verification
+- Healthcheck exits with code `0` and reports a fresh ingest timestamp.
+- Grafana lag panel drops below 12 minutes within two pipeline cycles.
+- No new files land in `data/dlq/` for the affected sources.
+
+### 2. Dedupe Drift
+- **Signal**: Alert `dedupe.near_duplicate_f1` (warning <0.93, page <0.90) or noticeable duplicate clusters in the ranked feed.
+- **Impact**: Users see repeated stories; reranker diversity guarantees no longer hold; scoring explanations degrade.
+- **Primary owner**: Dedupe/quality SME.
+
+#### Diagnosis Workflow
+1. **Quantify the drift** by running the regression suite:
+   ```bash
+   pytest tests/test_dedupe_utils.py
+   python scripts/dedupe_tuning.py --report
+   ```
+2. **Check recent clustering metrics** in the database:
+   ```bash
+   sqlite3 data/news.db "SELECT COUNT(*) FROM articles WHERE duplication_confidence > 0.8 AND collected_date > datetime('now', '-1 day');"
+   ```
+3. **Review canonicalization health** using the benchmark helper:
+   ```bash
+   python scripts/benchmark_canonicalize.py --sources nature science
+   ```
+4. **Inspect suspicious clusters** directly:
+   ```bash
+   python scripts/recluster_articles.py --cluster-id <uuid>
+   ```
+
+#### Remediation Steps
+- **Tokenizer or normalization regression**: roll back the offending commit or hotfix `src/utils/text_cleaner.py`, then rerun `pytest tests/test_text_cleaner.py` and `tests/test_dedupe_utils.py`.
+- **SimHash threshold tuning**: adjust `DEDUP_CONFIG["simhash_threshold"]` in `config/settings.py` and validate with `scripts/dedupe_tuning.py --simulate` before applying to production.
+- **Source specific anomalies**: temporarily suppress the source via `config/sources.py` (`is_active: false`) and coordinate with content owners.
+
+#### Verification
+- Run `python run_collector.py --healthcheck` to ensure pending articles are processing normally after dedupe fixes.
+- Confirm Grafana dedupe F1 recovers above 0.95 and manual spot-checks show diverse top stories.
+- Clear any temporary source suppressions after data quality stabilises.
+
+## Tooling Reference
+- `python run_collector.py --healthcheck` — fast signal for DB connectivity, queue backlog, and ingest recency.
+- `scripts/replay_outage.py` — reproduce historical outages and validate mitigations.
+- `scripts/dedupe_tuning.py` — stress-test SimHash thresholds.
+- `scripts/benchmark_canonicalize.py` — verify URL normalization after rule changes.
+- `docs/collector_runbook.md` — collector-specific operational guidance.

--- a/run_collector.py
+++ b/run_collector.py
@@ -335,7 +335,34 @@ Ejemplos de uso:
         "--check-deps", action="store_true", help="Verificar dependencias y salir"
     )
 
+    parser.add_argument(
+        "--healthcheck",
+        action="store_true",
+        help="Ejecutar healthcheck operativo (DB, cola, ingest) y salir",
+    )
+    parser.add_argument(
+        "--healthcheck-max-pending",
+        type=int,
+        default=None,
+        help="Umbral máximo de artículos pendientes para el healthcheck",
+    )
+    parser.add_argument(
+        "--healthcheck-max-ingest-minutes",
+        type=int,
+        default=None,
+        help="Umbral máximo de minutos de lag en la última ingesta",
+    )
+
     args = parser.parse_args()
+
+    if args.healthcheck:
+        from scripts.healthcheck import run_cli as run_healthcheck
+
+        success = run_healthcheck(
+            max_pending=args.healthcheck_max_pending,
+            max_ingest_lag_minutes=args.healthcheck_max_ingest_minutes,
+        )
+        sys.exit(0 if success else 1)
 
     # Verificar dependencias si se solicita
     if args.check_deps:

--- a/scripts/healthcheck.py
+++ b/scripts/healthcheck.py
@@ -1,0 +1,252 @@
+"""Operational healthcheck for the News Collector stack."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Dict, Iterable, Optional
+
+from sqlalchemy import func, text
+from sqlalchemy.exc import SQLAlchemyError
+
+from src import get_database_manager, setup_logging
+from src.storage.models import Article
+
+DEFAULT_MAX_PENDING = int(os.getenv("HEALTHCHECK_MAX_PENDING", "250"))
+DEFAULT_MAX_INGEST_LAG_MINUTES = int(os.getenv("HEALTHCHECK_MAX_INGEST_MINUTES", "180"))
+
+
+@dataclass
+class CheckResult:
+    """Represents the outcome of a single health check."""
+
+    name: str
+    status: str
+    details: Dict[str, Any]
+
+    def prefix(self) -> str:
+        if self.status == "ok":
+            return "✅"
+        if self.status == "warn":
+            return "⚠️"
+        return "❌"
+
+    def summary(self) -> str:
+        message = self.details.get("message")
+        if message:
+            return message
+
+        if self.name == "database":
+            return f"Database reachable via {self.details.get('engine', 'unknown')}"
+
+        if self.name == "queue_backlog":
+            pending = self.details.get("pending")
+            threshold = self.details.get("threshold")
+            return f"Pending articles: {pending} (threshold {threshold})"
+
+        if self.name == "latest_ingest":
+            latest = self.details.get("latest")
+            lag = self.details.get("lag_minutes")
+            threshold = self.details.get("threshold")
+            if latest is None:
+                return "No ingests recorded"
+            if lag is None:
+                return f"Last ingest at {latest}"
+            return (
+                f"Last ingest at {latest}; lag={lag:.1f} minutes "
+                f"(threshold {threshold} minutes)"
+            )
+
+        return self.name.replace("_", " ").title()
+
+
+def perform_healthcheck(
+    *,
+    db_manager=None,
+    now: Optional[datetime] = None,
+    max_pending: Optional[int] = None,
+    max_ingest_lag_minutes: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Run health validations for the collector stack."""
+
+    db_manager = db_manager or get_database_manager()
+    max_pending = DEFAULT_MAX_PENDING if max_pending is None else max_pending
+    max_ingest_lag_minutes = (
+        DEFAULT_MAX_INGEST_LAG_MINUTES
+        if max_ingest_lag_minutes is None
+        else max_ingest_lag_minutes
+    )
+    now = now or datetime.now(timezone.utc)
+
+    checks: list[CheckResult] = []
+
+    try:
+        with db_manager.get_session() as session:
+            session.execute(text("SELECT 1"))
+            total_articles = session.query(func.count(Article.id)).scalar() or 0
+            pending_articles = (
+                session.query(func.count(Article.id))
+                .filter(Article.processing_status == "pending")
+                .scalar()
+                or 0
+            )
+            latest_ingest: Optional[datetime] = (
+                session.query(func.max(Article.collected_date)).scalar()
+            )
+    except SQLAlchemyError as exc:  # pragma: no cover - defensive guard
+        checks.append(
+            CheckResult(
+                name="database",
+                status="fail",
+                details={"message": f"Database query failed: {exc}"},
+            )
+        )
+        return {"healthy": False, "checks": checks}
+    except Exception as exc:
+        checks.append(
+            CheckResult(
+                name="database",
+                status="fail",
+                details={"message": f"Database connection failed: {exc}"},
+            )
+        )
+        return {"healthy": False, "checks": checks}
+
+    checks.append(
+        CheckResult(
+            name="database",
+            status="ok",
+            details={"engine": db_manager.config.get("type", "unknown")},
+        )
+    )
+
+    backlog_status = "ok" if pending_articles <= max_pending else "fail"
+    checks.append(
+        CheckResult(
+            name="queue_backlog",
+            status=backlog_status,
+            details={"pending": pending_articles, "threshold": max_pending},
+        )
+    )
+
+    ingest_status = "ok"
+    ingest_details: Dict[str, Any] = {
+        "latest": latest_ingest.isoformat() if latest_ingest else None,
+        "threshold": max_ingest_lag_minutes,
+    }
+
+    if latest_ingest is None:
+        ingest_status = "fail"
+        ingest_details["message"] = "No ingestion records found"
+        ingest_details["lag_minutes"] = None
+    else:
+        if latest_ingest.tzinfo is None:
+            latest_ingest = latest_ingest.replace(tzinfo=timezone.utc)
+            ingest_details["latest"] = latest_ingest.isoformat()
+        lag_minutes = (now - latest_ingest).total_seconds() / 60.0
+        ingest_details["lag_minutes"] = lag_minutes
+        if lag_minutes > max_ingest_lag_minutes:
+            ingest_status = "fail"
+
+    checks.append(
+        CheckResult(
+            name="latest_ingest",
+            status=ingest_status,
+            details=ingest_details,
+        )
+    )
+
+    healthy = all(check.status == "ok" for check in checks)
+
+    return {
+        "healthy": healthy,
+        "checks": checks,
+        "summary": {
+            "total_articles": total_articles,
+            "pending_articles": pending_articles,
+            "latest_ingest": ingest_details.get("latest"),
+            "ingest_lag_minutes": ingest_details.get("lag_minutes"),
+        },
+    }
+
+
+def render_checks(checks: Iterable[CheckResult]) -> None:
+    """Pretty-print the check results for CLI users."""
+
+    for check in checks:
+        print(f"{check.prefix()} {check.name}: {check.summary()}")
+
+
+def run_cli(
+    *,
+    max_pending: Optional[int] = None,
+    max_ingest_lag_minutes: Optional[int] = None,
+    db_manager=None,
+) -> bool:
+    """Execute the healthcheck and print results."""
+
+    setup_logging()
+    result = perform_healthcheck(
+        db_manager=db_manager,
+        max_pending=max_pending,
+        max_ingest_lag_minutes=max_ingest_lag_minutes,
+    )
+
+    checks: Iterable[CheckResult] = result.get("checks", [])
+    render_checks(checks)
+
+    if summary := result.get("summary"):
+        latest = summary.get("latest_ingest")
+        lag = summary.get("ingest_lag_minutes")
+        pending = summary.get("pending_articles")
+        print(
+            "---\nSummary: "
+            f"latest_ingest={latest}, lag_minutes={lag}, pending_articles={pending}"
+        )
+
+    return bool(result.get("healthy"))
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Healthcheck for the Noticiencias News Collector. Validates database "
+            "connectivity, queue backlog, and ingest recency."
+        )
+    )
+    parser.add_argument(
+        "--max-pending",
+        type=int,
+        default=None,
+        help=(
+            "Maximum allowed pending articles before the queue backlog check fails. "
+            f"Defaults to {DEFAULT_MAX_PENDING}."
+        ),
+    )
+    parser.add_argument(
+        "--max-ingest-minutes",
+        type=int,
+        default=None,
+        help=(
+            "Maximum allowed lag in minutes between now and the latest ingest. "
+            f"Defaults to {DEFAULT_MAX_INGEST_LAG_MINUTES}."
+        ),
+    )
+    return parser
+
+
+def main(argv: Optional[list[str]] = None) -> None:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    success = run_cli(
+        max_pending=args.max_pending,
+        max_ingest_lag_minutes=args.max_ingest_minutes,
+    )
+    sys.exit(0 if success else 1)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()

--- a/tests/test_healthcheck.py
+++ b/tests/test_healthcheck.py
@@ -1,0 +1,52 @@
+"""Tests for the CLI healthcheck utility."""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+import sys
+
+import pytest
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from src.storage.database import DatabaseManager
+from src.storage.models import Article
+
+
+@pytest.fixture()
+def healthcheck_db(tmp_path):
+    """Create a temporary database populated with an old article."""
+
+    db_path = tmp_path / "healthcheck.db"
+    manager = DatabaseManager(database_config={"type": "sqlite", "path": db_path})
+
+    old_timestamp = datetime.now(timezone.utc) - timedelta(hours=2)
+    with manager.get_session() as session:
+        article = Article(
+            url="https://example.com/stale",
+            title="Artículo antiguo",
+            summary="Contenido mínimo para healthcheck.",
+            source_id="test_source",
+            source_name="Test Source",
+            category="science",
+            collected_date=old_timestamp,
+            processing_status="completed",
+        )
+        session.add(article)
+
+    return manager
+
+
+def test_healthcheck_failure_exit_code(monkeypatch, healthcheck_db):
+    """The CLI should exit with non-zero status when ingest lag exceeds threshold."""
+
+    import scripts.healthcheck as healthcheck
+
+    monkeypatch.setattr(healthcheck, "get_database_manager", lambda: healthcheck_db)
+
+    with pytest.raises(SystemExit) as excinfo:
+        healthcheck.main(["--max-ingest-minutes", "0", "--max-pending", "50"])
+
+    assert excinfo.value.code == 1


### PR DESCRIPTION
## Summary
- add a CLI healthcheck that validates database connectivity, queue backlog, and ingest recency
- expose the healthcheck via `run_collector.py` and document its usage in the new operations runbook
- cover the healthcheck failure path with automated tests and link the runbook from existing docs

## Testing
- pytest tests/test_healthcheck.py

------
https://chatgpt.com/codex/tasks/task_e_68dc66bccecc832fb258de4881990f6d