### PR TITLE
Refine CI workflow with dedicated jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,39 +9,145 @@ permissions:
   contents: read
 
 jobs:
-  quality-gates:
+  setup:
+    name: Setup
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Python
+        id: python
+        uses: actions/setup-python@v5
         with:
           python-version: '3.12'
           cache: 'pip'
-          cache-dependency-path: requirements.lock
+          cache-dependency-path: |
+            requirements.lock
+            requirements-security.lock
       - name: Bootstrap environment
         run: make bootstrap
+
+  lint:
+    name: Lint
+    needs: setup
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+          cache-dependency-path: |
+            requirements.lock
+            requirements-security.lock
       - name: Lint
         run: make lint
+
+  type:
+    name: Type check
+    needs: setup
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+          cache-dependency-path: |
+            requirements.lock
+            requirements-security.lock
       - name: Type check
         run: make typecheck
-      - name: Unit tests
+
+  test:
+    name: Test
+    needs: setup
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+          cache-dependency-path: |
+            requirements.lock
+            requirements-security.lock
+      - name: Run tests
         run: make test
-      - name: End-to-end checks
-        run: make e2e
-      - name: Performance checks
-        run: make perf
-      - name: Upload performance logs
-        if: ${{ always() }}
+      - name: Upload coverage report
+        if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: pipeline-perf-logs
+          name: coverage-reports
+          path: reports/coverage
+          if-no-files-found: warn
+
+  e2e:
+    name: End-to-end
+    needs: setup
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+          cache-dependency-path: |
+            requirements.lock
+            requirements-security.lock
+      - name: Run end-to-end suite
+        run: make e2e
+
+  perf:
+    name: Performance
+    needs: setup
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+          cache-dependency-path: |
+            requirements.lock
+            requirements-security.lock
+      - name: Run performance suite
+        run: make perf
+      - name: Upload performance reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: perf-reports
           path: reports/perf
           if-no-files-found: warn
-      - name: Security checks
-        id: security
-        continue-on-error: true
-        run: make security
 
+  security:
+    name: Security
+    needs: setup
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+          cache-dependency-path: |
+            requirements.lock
+            requirements-security.lock
+      - name: Run security scans
+        run: make security
       - name: Upload security reports
         if: always()
         uses: actions/upload-artifact@v4
@@ -49,9 +155,3 @@ jobs:
           name: security-reports
           path: reports/security
           if-no-files-found: warn
-
-      - name: Enforce security gate
-        if: steps.security.outcome == 'failure'
-        run: |
-          echo "High severity security findings detected. See security reports for details." >&2
-          exit 1

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 ## Sistema Automatizado de Recopilación y Scoring de Noticias Científicas
 
+[![CI](https://github.com/noticiencias/noticiencias_news_collector/actions/workflows/ci.yml/badge.svg)](https://github.com/noticiencias/noticiencias_news_collector/actions/workflows/ci.yml)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Status: MVP](https://img.shields.io/badge/Status-MVP-green.svg)]()


### PR DESCRIPTION
## Summary
- split the GitHub Actions CI into setup, lint, type, test, e2e, perf, and security jobs with pip caching
- enable coverage, performance, and security artifact uploads and run tests with coverage reporting
- surface the CI status badge in the README

## Testing
- make test

------
https://chatgpt.com/codex/tasks/task_e_68dc6929fc90832f9a9c2d39e0d24d1b