### PR TITLE
Automate versioning and release pipeline

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+.git
+.venv
+__pycache__
+reports
+*.pyc
+*.pyo
+*.pyd
+build
+dist
+.eggs
+*.egg-info
+.env

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,123 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  changelog:
+    name: Update changelog and draft release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Prepare git branch
+        run: |
+          git fetch origin main
+          git checkout main
+          git reset --hard "$GITHUB_SHA"
+      - name: Determine version metadata
+        id: vars
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          VERSION="${TAG#v}"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+      - name: Generate release notes
+        id: notes
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const tag = "${{ steps.vars.outputs.tag }}";
+            const response = await github.rest.repos.generateReleaseNotes({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag_name: tag,
+            });
+            const body = Buffer.from(response.data.body ?? "", "utf8").toString("base64");
+            core.setOutput("body_base64", body);
+      - name: Write release notes file
+        run: |
+          echo "${{ steps.notes.outputs.body_base64 }}" | base64 --decode > release-notes.md
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Update changelog
+        run: |
+          python scripts/update_changelog.py --version "${{ steps.vars.outputs.version }}" --notes-file release-notes.md
+      - name: Configure git user
+        run: |
+          git config user.name "noticiencias-release-bot"
+          git config user.email "infra+release@noticiencias.cl"
+      - name: Commit changelog updates
+        run: |
+          if git status --short | grep -q CHANGELOG.md; then
+            git add CHANGELOG.md
+            git commit -m "chore: finalize changelog for ${{ steps.vars.outputs.version }}"
+            git push origin HEAD:main
+          else
+            echo "Changelog already up to date"
+          fi
+      - name: Create draft release
+        uses: actions/create-release@v1
+        with:
+          tag_name: ${{ steps.vars.outputs.tag }}
+          release_name: ${{ steps.vars.outputs.tag }}
+          draft: true
+          body_path: release-notes.md
+
+  container:
+    name: Build release container image
+    runs-on: ubuntu-latest
+    needs: changelog
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Prepare image metadata
+        id: meta
+        run: |
+          DATE_TAG=$(date -u +%Y%m%d)
+          SHORT_SHA=$(git rev-parse --short HEAD)
+          IMAGE_TAG="noticiencias/collector:${DATE_TAG}.${SHORT_SHA}"
+          {
+            echo "date=${DATE_TAG}";
+            echo "short_sha=${SHORT_SHA}";
+            echo "image_tag=${IMAGE_TAG}";
+          } >> "$GITHUB_OUTPUT"
+      - name: Build container image
+        run: |
+          docker build -t ${{ steps.meta.outputs.image_tag }} .
+      - name: Export image and run instructions
+        run: |
+          docker save ${{ steps.meta.outputs.image_tag }} | gzip > collector-image.tar.gz
+          cat <<'EOT' > image-run.md
+          ## Ejecutar el contenedor del News Collector
+
+          ```bash
+          docker load < collector-image.tar.gz
+          docker run --rm \
+              ${{ steps.meta.outputs.image_tag }} --dry-run
+          ```
+
+          - Etiqueta: ${{ steps.meta.outputs.image_tag }}
+          - Fecha de build (UTC): ${{ steps.meta.outputs.date }}
+          - Commit: ${{ steps.meta.outputs.short_sha }}
+          EOT
+      - name: Publicar artefactos
+        uses: actions/upload-artifact@v4
+        with:
+          name: collector-container
+          path: |
+            collector-image.tar.gz
+            image-run.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ All notable changes to this project will be documented in this file. The format 
 - Arquitectura Mermaid en el README con enlaces a contratos compartidos para reforzar decisiones del pipeline.
 - Preguntas frecuentes de troubleshooting cubriendo bloqueos de BD, límites de tasa y modelos faltantes.
 - Referencias cruzadas a los runbooks y lineamientos de logging en la documentación operativa.
+- Módulo único de versionado con script/objetivo `make bump-version` para subir SemVer de forma segura.
+- Checklist de release que valida CI, budgets de performance/seguridad, documentación y bootstrap reproducible.
+- Automatización de changelog al crear tags que también genera borradores de GitHub Releases.
+- Dockerfile y job opcional de build que empaqueta la app como `noticiencias/collector:<fecha>.<sha>` con instrucciones de ejecución.
 
 ### Changed
 - Guía de contribución actualizada con estándares de código, convenciones de commits y proceso para refrescar fixtures tras la auditoría.
+- `pyproject.toml` ahora lee la versión directamente del módulo de configuración para evitar fuentes duplicadas.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+# syntax=docker/dockerfile:1
+FROM python:3.11-slim AS runtime
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
+
+WORKDIR /app
+
+# Instalamos dependencias con hashes reproducibles
+COPY requirements.lock ./requirements.lock
+RUN pip install --upgrade pip \
+    && pip install --require-hashes -r requirements.lock
+
+# Copiamos el código fuente
+COPY . .
+
+ENV PYTHONPATH=/app/src
+
+ENTRYPOINT ["python", "run_collector.py"]
+CMD ["--help"]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: bootstrap lint lint-fix typecheck test e2e perf security clean help
+.PHONY: bootstrap lint lint-fix typecheck test e2e perf security clean help bump-version
 
 VENV ?= .venv
 ifeq ($(OS),Windows_NT)
@@ -75,5 +75,15 @@ clean: ## Remove virtual environment and caches
 	@rm -rf $(VENV) .pytest_cache .mypy_cache
 
 help: ## Show this help message
-	@echo "Available targets:"
-	@grep -E '^[a-zA-Z_-]+:.*##' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*## "}; {printf "  %-12s %s\n", $$1, $$2}'
+        @echo "Available targets:"
+        @grep -E '^[a-zA-Z_-]+:.*##' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*## "}; {printf "  %-12s %s\n", $$1, $$2}'
+
+bump-version: ## Bump project version (PART=major|minor|patch or VERSION=X.Y.Z)
+        @if [ -n "$(VERSION)" ]; then \
+                $(PYTHON) scripts/bump_version.py --set "$(VERSION)"; \
+        elif [ -n "$(PART)" ]; then \
+                $(PYTHON) scripts/bump_version.py --part "$(PART)"; \
+        else \
+                echo "Usage: make bump-version PART=major|minor|patch | VERSION=X.Y.Z"; \
+                exit 1; \
+        fi

--- a/README.md
+++ b/README.md
@@ -188,6 +188,19 @@ python run_collector.py --healthcheck
 - Verifica conectividad con la base de datos, backlog en la cola de artículos pendientes y la frescura de la última ingesta.
 - Consulta el runbook completo en [`docs/runbook.md`](docs/runbook.md) para flujos de diagnóstico y resolución cuando el healthcheck falle.
 
+### Ejecutar en contenedor (experimental)
+```bash
+# Construye la imagen con la etiqueta sugerida (fecha UTC + short SHA)
+export TAG="$(date -u +%Y%m%d).$(git rev-parse --short HEAD)"
+docker build -t noticiencias/collector:${TAG} .
+
+# Ejecuta la imagen con la configuración incluida y realiza un dry-run
+docker run --rm \
+    noticiencias/collector:${TAG} --dry-run
+```
+
+El workflow `Release` empaqueta automáticamente la imagen `noticiencias/collector:<fecha>.<sha>` como artefacto. Cada ejecución adjunta un archivo `image-run.md` con instrucciones para cargarla mediante `docker load` y repetir los pasos de bootstrap dentro del contenedor.
+
 ---
 
 ## 📚 Fuentes Configuradas

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -32,10 +32,11 @@ from .sources import (
 from .version import (
     MIN_PYTHON_VERSION,
     MIN_PYTHON_VERSION_STR,
+    PROJECT_VERSION,
     PYTHON_REQUIRES_SPECIFIER,
+    __version__,
 )
 
-__version__ = "1.0.0"
 __author__ = "News Collector Team"
 
 __all__ = [
@@ -60,5 +61,7 @@ __all__ = [
     "validate_sources",
     "MIN_PYTHON_VERSION",
     "MIN_PYTHON_VERSION_STR",
+    "PROJECT_VERSION",
     "PYTHON_REQUIRES_SPECIFIER",
+    "__version__",
 ]

--- a/config/version.py
+++ b/config/version.py
@@ -1,14 +1,53 @@
 """Project-level versioning and compatibility metadata."""
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Final, Tuple
 
 MIN_PYTHON_VERSION: Final[Tuple[int, int]] = (3, 10)
 MIN_PYTHON_VERSION_STR: Final[str] = ".".join(str(part) for part in MIN_PYTHON_VERSION)
 PYTHON_REQUIRES_SPECIFIER: Final[str] = f">={MIN_PYTHON_VERSION_STR}"
 
+
+@dataclass(frozen=True)
+class VersionMetadata:
+    """Immutable container for semantic version information."""
+
+    major: int
+    minor: int
+    patch: int
+
+    def __post_init__(self) -> None:
+        for attribute_name, value in (
+            ("major", self.major),
+            ("minor", self.minor),
+            ("patch", self.patch),
+        ):
+            if value < 0:
+                raise ValueError(f"{attribute_name} must be non-negative, got {value}")
+
+    def __str__(self) -> str:  # pragma: no cover - simple formatting helper
+        return f"{self.major}.{self.minor}.{self.patch}"
+
+    @property
+    def tuple(self) -> Tuple[int, int, int]:
+        """Return the version tuple for convenience in tooling."""
+
+        return (self.major, self.minor, self.patch)
+
+
+PROJECT_VERSION: Final[str] = "1.0.0"
+VERSION_INFO: Final[VersionMetadata] = VersionMetadata(
+    *tuple(int(part) for part in PROJECT_VERSION.split("."))
+)
+__version__: Final[str] = PROJECT_VERSION
+
 __all__ = [
     "MIN_PYTHON_VERSION",
     "MIN_PYTHON_VERSION_STR",
     "PYTHON_REQUIRES_SPECIFIER",
+    "PROJECT_VERSION",
+    "VERSION_INFO",
+    "__version__",
+    "VersionMetadata",
 ]

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -1,0 +1,28 @@
+# ✅ Release Checklist
+
+Esta lista asegura que cada release del News Collector cumple los contratos operativos definidos en `AGENTS.md#9`. Marca cada elemento antes de crear un tag `vX.Y.Z`.
+
+## 1. Salud de CI
+- [ ] Todas las ejecuciones de `CI` en GitHub Actions están en verde (lint, typecheck, test, e2e, perf, security).
+- [ ] No hay regresiones abiertas en la matriz de pruebas manuales.
+
+## 2. Presupuestos de Performance y Seguridad
+- [ ] Los reportes en `reports/perf` están dentro de los budgets publicados en el runbook.
+- [ ] `make security` está libre de hallazgos HIGH y el gate (`scripts/security_gate.py`) marca estado `pass`.
+
+## 3. Documentación y Comunicación
+- [ ] `CHANGELOG.md` refleja los cambios planeados para la versión.
+- [ ] Documentación en `docs/` y `README.md` está actualizada con nuevos flags, dependencias o flujos.
+- [ ] Las notas de release generadas automáticamente fueron revisadas y editadas si es necesario.
+
+## 4. Verificación Operacional
+- [ ] `make bump-version PART=<major|minor|patch>` o `make bump-version VERSION=X.Y.Z` ejecutado y versionado commit.
+- [ ] `make bootstrap` se ejecuta exitosamente en un entorno limpio (incluye `requirements.lock` + `requirements-security.lock`).
+- [ ] `python run_collector.py --dry-run` produce resultados consistentes y sin errores.
+
+## 5. Artefactos y Deploy
+- [ ] El workflow `Release` terminó en verde, creó el borrador de GitHub Release y actualizó el changelog automáticamente.
+- [ ] El job opcional `Build release container` generó el artefacto `noticiencias/collector:<fecha>.<sha>` y se revisaron las instrucciones de ejecución incluidas.
+- [ ] Se registró la fecha de despliegue en el log operativo.
+
+> Sugerencia: Guarda esta checklist como parte del issue o ticket de release para trazabilidad.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "noticiencias-news-collector"
-version = "0.0.0"
+dynamic = ["version"]
 description = "Scientific news aggregation pipeline for the Noticiencias project"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -16,6 +16,9 @@ security = [
 [build-system]
 requires = ["setuptools>=64", "wheel"]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools.dynamic]
+version = {attr = "config.version.__version__"}
 
 [tool.ruff]
 target-version = "py310"

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Utility script to bump the project semantic version."""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+from typing import Final, Tuple
+
+VERSION_FILE: Final[Path] = Path("config") / "version.py"
+PROJECT_VERSION_PATTERN: Final[re.Pattern[str]] = re.compile(
+    r'^(?P<prefix>PROJECT_VERSION\s*:\s*Final\[str\]\s*=\s*")'
+    r'(?P<version>[^"\n]+)'
+    r'(?P<suffix>"\s*)$'
+)
+SEMVER_RE: Final[re.Pattern[str]] = re.compile(
+    r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$"
+)
+
+
+class VersionBumpError(RuntimeError):
+    """Raised when the version cannot be bumped automatically."""
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Bump the project version in config/version.py",
+    )
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument(
+        "--part",
+        choices=("major", "minor", "patch"),
+        help="Which semantic version component to increment.",
+    )
+    group.add_argument(
+        "--set",
+        dest="explicit_version",
+        metavar="X.Y.Z",
+        help="Set an explicit semantic version.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show the computed version without writing changes.",
+    )
+    return parser.parse_args(argv)
+
+
+def read_current_version() -> Tuple[str, list[str]]:
+    lines = VERSION_FILE.read_text(encoding="utf-8").splitlines()
+    for line in lines:
+        match = PROJECT_VERSION_PATTERN.match(line.strip())
+        if match:
+            return match.group("version"), lines
+    raise VersionBumpError(
+        "PROJECT_VERSION declaration not found in config/version.py",
+    )
+
+
+def validate_semver(version: str) -> Tuple[int, int, int]:
+    match = SEMVER_RE.fullmatch(version)
+    if not match:
+        raise VersionBumpError(f"Invalid semantic version: {version}")
+    major, minor, patch = (int(part) for part in match.groups())
+    return major, minor, patch
+
+
+def compute_next_version(current: str, part: str | None, explicit: str | None) -> str:
+    if explicit:
+        validate_semver(explicit)
+        return explicit
+    if part is None:
+        raise VersionBumpError("Either --part or --set must be supplied")
+    major, minor, patch = validate_semver(current)
+    if part == "major":
+        major += 1
+        minor = 0
+        patch = 0
+    elif part == "minor":
+        minor += 1
+        patch = 0
+    else:
+        patch += 1
+    return f"{major}.{minor}.{patch}"
+
+
+def write_version(lines: list[str], new_version: str) -> None:
+    updated_lines: list[str] = []
+    for line in lines:
+        stripped = line.strip()
+        match = PROJECT_VERSION_PATTERN.match(stripped)
+        if match:
+            updated_line = f"{match.group('prefix')}{new_version}{match.group('suffix')}"
+            leading = line[: len(line) - len(stripped)]
+            updated_lines.append(f"{leading}{updated_line}")
+        else:
+            updated_lines.append(line)
+    VERSION_FILE.write_text("\n".join(updated_lines) + "\n", encoding="utf-8")
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    try:
+        current_version, lines = read_current_version()
+        new_version = compute_next_version(
+            current_version,
+            part=args.part,
+            explicit=args.explicit_version,
+        )
+        if args.dry_run:
+            print(new_version)
+            return 0
+        write_version(lines, new_version)
+        print(new_version)
+        return 0
+    except VersionBumpError as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/update_changelog.py
+++ b/scripts/update_changelog.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Automate changelog updates during tagged releases."""
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import re
+import sys
+from pathlib import Path
+from typing import Final
+
+CHANGELOG_PATH: Final[Path] = Path("CHANGELOG.md")
+UNRELEASED_HEADER: Final[str] = "## [Unreleased]"
+HEADING_PATTERN: Final[re.Pattern[str]] = re.compile(r"^(?P<hashes>#+)(?P<text>\s.*)$")
+
+
+class ChangelogUpdateError(RuntimeError):
+    """Raised when the changelog cannot be updated."""
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Update CHANGELOG.md with release notes")
+    parser.add_argument("--version", required=True, help="Release version without the leading 'v'")
+    parser.add_argument(
+        "--notes-file",
+        required=True,
+        help="Path to a file containing release notes (Markdown).",
+    )
+    return parser.parse_args(argv)
+
+
+def ensure_semver(version: str) -> None:
+    if not re.fullmatch(r"(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)", version):
+        raise ChangelogUpdateError(f"Version '{version}' is not a valid SemVer string")
+
+
+def read_release_notes(path: Path) -> str:
+    if not path.exists():
+        raise ChangelogUpdateError(f"Release notes file '{path}' not found")
+    return path.read_text(encoding="utf-8").strip()
+
+
+def adjust_markdown_headings(notes: str) -> str:
+    adjusted_lines: list[str] = []
+    for line in notes.splitlines():
+        match = HEADING_PATTERN.match(line.lstrip())
+        if match and len(match.group("hashes")) >= 2:
+            leading_spaces = " " * (len(line) - len(line.lstrip()))
+            new_hashes = "#" * (len(match.group("hashes")) + 1)
+            adjusted_lines.append(f"{leading_spaces}{new_hashes}{match.group('text')}")
+        else:
+            adjusted_lines.append(line)
+    return "\n".join(adjusted_lines).strip()
+
+
+def extract_unreleased_block(changelog_text: str) -> tuple[str, str, str]:
+    if UNRELEASED_HEADER not in changelog_text:
+        raise ChangelogUpdateError("CHANGELOG.md must include an '## [Unreleased]' heading")
+    start_index = changelog_text.index(UNRELEASED_HEADER)
+    after_header = start_index + len(UNRELEASED_HEADER)
+    next_release_index = changelog_text.find("\n## [", after_header)
+    if next_release_index == -1:
+        next_release_index = len(changelog_text)
+    prefix = changelog_text[:after_header]
+    unreleased_content = changelog_text[after_header:next_release_index]
+    suffix = changelog_text[next_release_index:]
+    return prefix, unreleased_content, suffix
+
+
+def build_release_block(version: str, unreleased: str, release_notes: str) -> str:
+    today = dt.date.today().isoformat()
+    sections: list[str] = []
+    if unreleased.strip():
+        sections.append(unreleased.strip())
+    if release_notes.strip():
+        sections.append(adjust_markdown_headings(release_notes))
+    body = "\n\n".join(section.rstrip() for section in sections if section)
+    return f"\n\n## [{version}] - {today}\n\n{body}\n"
+
+
+def update_changelog(version: str, release_notes_path: Path) -> None:
+    ensure_semver(version)
+    changelog_text = CHANGELOG_PATH.read_text(encoding="utf-8")
+    release_notes = read_release_notes(release_notes_path)
+    prefix, unreleased_content, suffix = extract_unreleased_block(changelog_text)
+    release_block = build_release_block(version, unreleased_content, release_notes)
+    placeholder = "\n\n### Added\n- _Pending release notes_\n"
+    updated = f"{prefix}{placeholder}{release_block}{suffix.lstrip('\n')}"
+    if not updated.endswith("\n"):
+        updated += "\n"
+    CHANGELOG_PATH.write_text(updated, encoding="utf-8")
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    try:
+        update_changelog(args.version, Path(args.notes_file))
+    except ChangelogUpdateError as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -5,7 +5,7 @@ Contiene los módulos funcionales del sistema: colectores, scoring,
 almacenamiento y utilidades.
 """
 
-from config.version import PYTHON_REQUIRES_SPECIFIER
+from config.version import PROJECT_VERSION, PYTHON_REQUIRES_SPECIFIER
 
 from .collectors import RSSCollector, BaseCollector
 from .scoring import BasicScorer, score_multiple_articles
@@ -13,7 +13,7 @@ from .storage import get_database_manager, DatabaseManager
 from .serving import create_app
 from .utils import get_logger, setup_logging, get_metrics_reporter
 
-__version__ = "1.0.0"
+__version__ = PROJECT_VERSION
 __description__ = (
     "Sistema automatizado de recopilación y scoring de noticias científicas"
 )


### PR DESCRIPTION
## Summary
- centralize project version metadata and expose it via pyproject, config, and package exports
- add tooling for SemVer bumps (script + make target) and a release checklist for operational sign-off
- create a release workflow that updates CHANGELOG.md, drafts GitHub releases, and publishes a container artifact with usage docs

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dc778b61e8832fb502df1b2aa81821