### PR TITLE
Fix mypy errors in collector pipeline and perf tests

### DIFF
--- a/tests/collector_pipeline_types.py
+++ b/tests/collector_pipeline_types.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TypedDict
+
+
+class SourceFixture(TypedDict):
+    id: str
+    name: str
+    url: str
+    category: str
+    credibility_score: float
+    language: str
+
+
+class CollectorRawMetadata(TypedDict, total=False):
+    feed_title: str
+    content: str
+    doi: str | None
+
+
+class CollectorRawFixture(TypedDict, total=False):
+    url: str
+    title: str
+    summary: str
+    authors: list[str]
+    published_offset_hours: int
+    published_date: datetime
+    published_tz_offset_minutes: int
+    published_tz_name: str
+    original_url: str
+    source_metadata: CollectorRawMetadata
+
+
+class EnrichmentExpected(TypedDict):
+    language: str
+    sentiment: str
+    topics: list[str]
+    entities: list[str]
+
+
+class ExpectedStorageFields(TypedDict):
+    language: str
+    category: str
+    source_id: str
+
+
+class ExpectedStorage(TypedDict):
+    fields: ExpectedStorageFields
+    final_score_min: float
+    should_include: bool
+
+
+class PipelineEntry(TypedDict):
+    id: str
+    source: SourceFixture
+    collector_raw: CollectorRawFixture
+    enrichment_expected: EnrichmentExpected
+    expected_storage: ExpectedStorage

--- a/tests/perf/test_async_collector_perf.py
+++ b/tests/perf/test_async_collector_perf.py
@@ -2,7 +2,7 @@ import asyncio
 import sys
 from pathlib import Path
 from time import perf_counter, sleep
-from typing import Dict
+from typing import Any
 
 import pytest
 
@@ -26,7 +26,7 @@ class DummyDB:
     def __init__(self):
         self.saved = []
 
-    def get_source_feed_metadata(self, source_id: str) -> Dict[str, str]:
+    def get_source_feed_metadata(self, source_id: str) -> dict[str, str | None]:
         return {"etag": None, "last_modified": None}
 
     def update_source_feed_metadata(
@@ -38,7 +38,7 @@ class DummyDB:
     ) -> None:
         return None
 
-    def update_source_stats(self, source_id: str, stats: Dict[str, float]) -> None:
+    def update_source_stats(self, source_id: str, stats: dict[str, float]) -> None:
         return None
 
     def save_article(self, article):
@@ -138,7 +138,7 @@ def _stub_common_behaviour(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("httpx.AsyncClient", lambda *args, **kwargs: DummyAsyncClient())
 
 
-def _build_sources() -> Dict[str, Dict[str, str]]:
+def _build_sources() -> dict[str, dict[str, Any]]:
     return {
         f"source-{idx}": {
             "name": f"Source {idx}",


### PR DESCRIPTION
## Summary
- extract shared TypedDict definitions for collector pipeline fixtures
- update pipeline e2e and perf tests to use the typed fixtures and explicit casts
- adjust async collector perf test stubs so metadata and source dictionaries match their runtime values

## Testing
- make typecheck

------
https://chatgpt.com/codex/tasks/task_e_68dc9830fdb0832faea3efd7bfcd0510