### PR TITLE
Fix test type hints for mypy

### DIFF
--- a/tests/perf/test_async_collector_perf.py
+++ b/tests/perf/test_async_collector_perf.py
@@ -2,7 +2,7 @@ import asyncio
 import sys
 from pathlib import Path
 from time import perf_counter, sleep
-from typing import Dict
+from typing import Any, Dict
 
 import pytest
 
@@ -26,7 +26,7 @@ class MockDB:
     def __init__(self):
         self.saved = []
 
-    def get_source_feed_metadata(self, source_id: str) -> Dict[str, str]:
+    def get_source_feed_metadata(self, source_id: str) -> Dict[str, str | None]:
         return {"etag": None, "last_modified": None}
 
     def update_source_feed_metadata(
@@ -138,7 +138,7 @@ def _stub_common_behaviour(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("httpx.AsyncClient", lambda *args, **kwargs: MockAsyncClient())
 
 
-def _build_sources() -> Dict[str, Dict[str, str]]:
+def _build_sources() -> Dict[str, Dict[str, Any]]:
     return {
         f"source-{idx}": {
             "name": f"Source {idx}",


### PR DESCRIPTION
## Summary
- adjust mock database and source factory annotations in async collector perf test to accept optional metadata values
- add explicit dataset typing and runtime validation in pipeline E2E test to make JSON fixtures mypy-friendly
- update pipeline perf test typings and enrichment wrapper signature to match ArticleForEnrichmentModel expectations

## Testing
- make typecheck

------
https://chatgpt.com/codex/tasks/task_e_68dca30fa8a4832fb8ddf8d66b9f1b78