### PR TITLE
Fix GUI configuration persistence of optional values

### DIFF
--- a/noticiencias/config_schema.py
+++ b/noticiencias/config_schema.py
@@ -149,6 +149,27 @@ class DatabaseConfig(StrictModel):
         description="Seconds after which pooled connections are recycled.",
     )
 
+    @field_validator("host", "user", "password", "sslmode", mode="before")
+    @classmethod
+    def _blank_to_none(cls, value: Any) -> Any:
+        if isinstance(value, str) and not value.strip():
+            return None
+        return value
+
+    @field_validator("port", mode="before")
+    @classmethod
+    def _normalize_port(cls, value: Any) -> Any:
+        if value is None:
+            return None
+        if isinstance(value, str):
+            text = value.strip()
+            if not text:
+                return None
+            if not text.isdigit():
+                raise ValueError("port must be a positive integer")
+            return int(text)
+        return value
+
     @model_validator(mode="after")
     def _validate_backend(self) -> "DatabaseConfig":
         driver = self.driver.lower()

--- a/noticiencias/gui_config.py
+++ b/noticiencias/gui_config.py
@@ -448,17 +448,29 @@ class ConfigEditor:
         if raw.lower() == "none" and default is None:
             return None
         if isinstance(default, int) and not isinstance(default, bool):
-            return int(raw)
+            try:
+                return int(raw)
+            except ValueError as exc:
+                raise ConfigError(f"{name} must be an integer") from exc
         if isinstance(default, float):
-            return float(raw)
+            try:
+                return float(raw)
+            except ValueError as exc:
+                raise ConfigError(f"{name} must be a number") from exc
         if isinstance(default, list):
             if raw.startswith("["):
-                return json.loads(raw)
+                try:
+                    return json.loads(raw)
+                except json.JSONDecodeError as exc:
+                    raise ConfigError(f"{name} must be valid JSON") from exc
             return [part.strip() for part in raw.split(",") if part.strip()]
         if isinstance(default, dict):
             if not raw:
                 return {}
-            return json.loads(raw)
+            try:
+                return json.loads(raw)
+            except json.JSONDecodeError as exc:
+                raise ConfigError(f"{name} must be valid JSON") from exc
         if isinstance(default, bool):
             return raw.lower() in {"true", "1", "yes"}
         return raw


### PR DESCRIPTION
## Summary
- avoid serializing unset configuration values as empty strings so GUI saves round-trip correctly
- normalize blank database connection fields and surface parsing errors early in the GUI
- add regression coverage for database port normalization and persistence

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dda8f35788832f84413831551d0f07