### PR TITLE
Fix sync_lockfiles script to use relative paths

### DIFF
--- a/scripts/sync_lockfiles.py
+++ b/scripts/sync_lockfiles.py
@@ -10,7 +10,7 @@ from typing import Sequence
 
 LOGGER = logging.getLogger("sync_lockfiles")
 ROOT_DIR = Path(__file__).resolve().parent.parent
-LOCK_TARGETS = (
+LOCK_TARGETS: tuple[tuple[str, tuple[str, ...]], ...] = (
     (
         "requirements.lock",
         (
@@ -19,8 +19,8 @@ LOCK_TARGETS = (
             "compile",
             "--generate-hashes",
             "--output-file",
-            str(ROOT_DIR / "requirements.lock"),
-            str(ROOT_DIR / "requirements.txt"),
+            "requirements.lock",
+            "requirements.txt",
         ),
     ),
     (
@@ -34,8 +34,8 @@ LOCK_TARGETS = (
             "--extra",
             "security",
             "--output-file",
-            str(ROOT_DIR / "requirements-security.lock"),
-            str(ROOT_DIR / "pyproject.toml"),
+            "requirements-security.lock",
+            "pyproject.toml",
         ),
     ),
 )


### PR DESCRIPTION
## Summary
- ensure the lockfile refresh script calls pip-compile with repository-relative paths to avoid environment-specific comments

## Testing
- python scripts/sync_lockfiles.py --check

------
https://chatgpt.com/codex/tasks/task_e_68ddb95fc7ac832f8bfadf4c477aae5d