### PR TITLE
Adjust manual lock sync workflow for org policy

### DIFF
--- a/.github/workflows/manual-lock-sync.yml
+++ b/.github/workflows/manual-lock-sync.yml
@@ -30,21 +30,37 @@ jobs:
           python-version: '3.12'
       - name: Refresh lockfiles
         run: python scripts/sync_lockfiles.py --install-pip-tools
-      - name: Create pull request
-        uses: peter-evans/create-pull-request@v6
-        with:
-          branch: automation/lock-sync
-          branch-suffix: timestamp
-          base: ${{ github.event.inputs['base-branch'] || 'main' }}
-          commit-message: "chore: refresh dependency lockfiles"
-          title: ${{ github.event.inputs['pr-title'] }}
-          body: |
-            ## Summary
-            - Regenerated requirements.lock and requirements-security.lock using `scripts/sync_lockfiles.py`.
+      - name: Commit and push lockfile updates
+        env:
+          BASE_BRANCH: ${{ github.event.inputs['base-branch'] || 'main' }}
+          PR_TITLE: ${{ github.event.inputs['pr-title'] }}
+        run: |
+          set -euo pipefail
 
-            ## Details
-            - Triggered manually via workflow_dispatch.
-          add-paths: |
-            requirements.lock
-            requirements-security.lock
-          delete-branch: true
+          if git diff --quiet -- requirements.lock requirements-security.lock; then
+            {
+              echo "## Manual follow-up"
+              echo "No lockfile changes detected. Nothing to push or review."
+            } >> "${GITHUB_STEP_SUMMARY}"
+            exit 0
+          fi
+
+          branch_suffix="$(date +%s)"
+          branch_name="automation/lock-sync-${branch_suffix}"
+
+          git config --global user.email "action@github.com"
+          git config --global user.name "github-actions[bot]"
+
+          git checkout -b "${branch_name}"
+          git add requirements.lock requirements-security.lock
+          git commit -m "chore: refresh dependency lockfiles"
+          git push --set-upstream origin "${branch_name}"
+
+          {
+            echo "## Manual follow-up"
+            echo "Lockfile updates have been pushed to \`${branch_name}\`."
+            echo "Create a pull request merging **${BASE_BRANCH}** <- **${branch_name}** with the suggested title:"
+            echo "- ${PR_TITLE:-chore: refresh dependency lockfiles}"
+            echo ""
+            echo "GitHub Actions cannot open the PR automatically due to organization policy."
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Las interfaces entre etapas se documentan en [AGENTS.md](AGENTS.md), y los contr
 
 ## Instalación
 ### Prerrequisitos
-- Python 3.10+ (probado en 3.12).
+- Python 3.10 o superior (probado en 3.12).
 - Git.
 - (Opcional) Docker 24+ para empaquetar contenedores.
 
@@ -204,7 +204,7 @@ Workflows en `.github/workflows/`:
 - `ci.yml`: lint, tests y seguridad en pushes/PRs.
 - `security.yml`: escaneos dedicados (bandit, trufflehog, pip-audit).
 - `dependency-lock-check.yml`: valida sincronía de lockfiles.
-- `manual-lock-sync.yml`: job manual para refrescar `requirements.lock`.
+- `manual-lock-sync.yml`: job manual para refrescar `requirements.lock`; empuja una rama auxiliar y requiere crear el PR manualmente.
 - `release.yml`: empaquetado y publicación (ver [release checklist](docs/release-checklist.md)).
 - `sync-master.yml`: sincronización con ramas ascendentes.
 


### PR DESCRIPTION
## Summary
- update the manual lockfile workflow to create and push a timestamped branch instead of opening a PR automatically
- add run summary guidance so operators know to open the PR manually when the workflow runs
- document the manual PR requirement and restate the supported Python version in the README

## Testing
- make lint
- make typecheck
- make test
- ./.venv/bin/bandit -ll -r src
- ./.venv/bin/gitleaks detect --source . --no-banner *(fails: binary unavailable in environment)*
- ./.venv/bin/pip-audit


------
https://chatgpt.com/codex/tasks/task_e_68de85900aa0832fb90b8c21d88dc396