### PR TITLE
Fix Makefile indentation and add tab check

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,7 @@ Thanks for helping us keep the Noticiencias stack healthy! This document capture
 
 - Target **Python 3.10+** and keep functions annotated. Use `TypedDict`, `Protocol`, or dataclasses when sharing structures across modules.
 - Follow **PEP 8** plus `ruff` defaults for style. Keep `structlog`-style dictionaries in logging statements with `trace_id`, `source_id`, and `article_id`.
+- Keep Makefile recipes tab-indented; `make lint` now fails fast if spaces sneak into command lines.
 - Persist and compare timestamps in **UTC**; convert to `America/Santiago` only inside presentation layers.
 - Never swallow exceptions—wrap them with context and re-raise so the DLQ/runbooks have usable breadcrumbs.
 

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ bootstrap: $(BOOTSTRAP_STAMP) ## Provision local environment with dependencies
 	@echo "Environment ready at $(VENV)"
 
 lint: bootstrap ## Run Ruff lint checks
+	@$(PYTHON_BIN) tools/check_makefile_tabs.py Makefile
 	@$(RUFF) check src tests scripts
 
 lint-fix: bootstrap ## Run Ruff with autofix enabled
@@ -151,14 +152,14 @@ help: ## Show this help message
 	@grep -E '^[a-zA-Z_-]+:.*##' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*## "}; {printf "  %-12s %s\n", $$1, $$2}'
 
 bump-version: ## Bump project version (PART=major|minor|patch or VERSION=X.Y.Z)
-        @if [ -n "$(VERSION)" ]; then \
-                $(PYTHON) scripts/bump_version.py --set "$(VERSION)"; \
-        elif [ -n "$(PART)" ]; then \
-                $(PYTHON) scripts/bump_version.py --part "$(PART)"; \
-        else \
-                echo "Usage: make bump-version PART=major|minor|patch | VERSION=X.Y.Z"; \
-                exit 1; \
-        fi
+	@if [ -n "$(VERSION)" ]; then \
+		$(PYTHON) scripts/bump_version.py --set "$(VERSION)"; \
+	elif [ -n "$(PART)" ]; then \
+		$(PYTHON) scripts/bump_version.py --part "$(PART)"; \
+	else \
+		echo "Usage: make bump-version PART=major|minor|patch | VERSION=X.Y.Z"; \
+		exit 1; \
+	fi
 
 .PHONY: audit-placeholders
 audit-placeholders:

--- a/tests/tools/test_check_makefile_tabs.py
+++ b/tests/tools/test_check_makefile_tabs.py
@@ -1,0 +1,26 @@
+"""Tests for the Makefile tab indentation validator."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from tools.check_makefile_tabs import find_tab_violations, validate_makefiles
+
+
+def test_find_tab_violations_detects_space_indented_recipe(tmp_path: Path) -> None:
+    makefile = tmp_path / "Makefile"
+    makefile.write_text("target:\n    echo hi\n", encoding="utf-8")
+
+    violations = find_tab_violations(makefile)
+
+    assert len(violations) == 1
+    assert violations[0].line_number == 2
+    assert violations[0].line.startswith("    echo")
+
+
+def test_validate_makefiles_accepts_tab_indented_recipe(tmp_path: Path) -> None:
+    makefile = tmp_path / "Makefile"
+    makefile.write_text("target:\n\t@echo hi\n", encoding="utf-8")
+
+    exit_code = validate_makefiles((makefile,))
+
+    assert exit_code == 0

--- a/tools/check_makefile_tabs.py
+++ b/tools/check_makefile_tabs.py
@@ -1,0 +1,90 @@
+"""Validate that Makefile recipes use tab indentation."""
+from __future__ import annotations
+
+import argparse
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Sequence
+
+
+@dataclass(frozen=True)
+class TabViolation:
+    """Record of a Makefile line that is not tab-indented."""
+
+    path: Path
+    line_number: int
+    line: str
+
+
+def _iter_lines(path: Path) -> Iterable[tuple[int, str]]:
+    content = path.read_text(encoding="utf-8").splitlines()
+    for index, value in enumerate(content, start=1):
+        yield index, value
+
+
+def find_tab_violations(path: Path) -> list[TabViolation]:
+    """Return all lines in ``path`` that start with spaces instead of tabs."""
+
+    violations: list[TabViolation] = []
+    for line_number, line in _iter_lines(path):
+        stripped = line.lstrip()
+        if not stripped:
+            continue
+        if stripped.startswith("#"):
+            continue
+        if line.startswith("\t"):
+            continue
+        if line.startswith(" "):
+            violations.append(TabViolation(path=path, line_number=line_number, line=line))
+    return violations
+
+
+def _format_violation(violation: TabViolation) -> str:
+    return (
+        f"{{\"path\": \"{violation.path.as_posix()}\", "
+        f"\"line\": {violation.line_number}, "
+        f"\"content\": \"{violation.line.replace('\\', '\\\\').replace('\"', '\\\"')}\"}}"
+    )
+
+
+def validate_makefiles(paths: Sequence[Path]) -> int:
+    """Validate each Makefile path and emit structured errors."""
+
+    exit_code = 0
+    for path in paths:
+        if not path.exists():
+            message = (
+                f'{{"path": "{path.as_posix()}", '
+                f'"error": "file does not exist"}}\n'
+            )
+            sys.stderr.write(message)
+            return 1
+        violations = find_tab_violations(path)
+        if not violations:
+            continue
+        exit_code = 1
+        for violation in violations:
+            sys.stdout.write(f"{_format_violation(violation)}\n")
+    return exit_code
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        type=Path,
+        default=(Path("Makefile"),),
+        help="Makefile paths to validate.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    return validate_makefiles(tuple(args.paths))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- fix the `bump-version` recipe so its commands are tab-indented and Make targets build correctly again
- add a reusable Makefile tab validator that runs as part of `make lint`, with coverage tests for the checker
- document the tab-indentation requirement for contributors to prevent future CI failures

## Testing
- make bootstrap
- make lint
- make typecheck
- make test
- pip-audit -r requirements.txt --format columns
- bandit -r src scripts -c .bandit --severity-level high --confidence-level high
- /tmp/gitleaks detect --source . --no-git --report-path reports/security/gitleaks.json --report-format json --redact --no-banner

------
https://chatgpt.com/codex/tasks/task_e_68de9a831f50832f9f523d9dce7ed4c3