### PR TITLE
Fix Makefile tabs and add remediation workflow

### DIFF
--- a/.github/workflows/fix-makefile-tabs.yml
+++ b/.github/workflows/fix-makefile-tabs.yml
@@ -1,0 +1,58 @@
+name: Fix Makefile tabs
+
+on:
+  workflow_dispatch:
+    inputs:
+      base_branch:
+        description: "Branch to open the pull request against"
+        required: false
+        default: main
+      branch_suffix:
+        description: "Optional suffix for the generated branch"
+        required: false
+        default: ""
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  fix-tabs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Normalize Makefile indentation
+        run: python -m tools.fix_makefile_tabs
+      - name: Detect changes
+        id: diff
+        run: |
+          if git diff --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Create pull request
+        if: steps.diff.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore: normalize Makefile tabs"
+          title: "chore: normalize Makefile tabs"
+          body: |
+            ## Summary
+            - Run `python -m tools.fix_makefile_tabs` to normalize Makefile recipes.
+
+            ## Notes
+            - Triggered by `${{ github.actor }}` via workflow dispatch.
+          branch: >-
+            chore/normalize-makefile-tabs${{ inputs.branch_suffix && format('-{0}', inputs.branch_suffix) || '' }}
+          base: ${{ inputs.base_branch }}
+          delete-branch: true
+      - name: No changes summary
+        if: steps.diff.outputs.changed != 'true'
+        run: echo "No indentation updates were necessary." >> "$GITHUB_STEP_SUMMARY"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: bootstrap lint lint-fix typecheck test e2e perf security clean help bump-version audit-todos audit-todos-baseline audit-todos-check
+.PHONY: bootstrap lint lint-fix fix-makefile-tabs typecheck test e2e perf security clean help bump-version audit-todos audit-todos-baseline audit-todos-check
 
 VENV ?= .venv
 ifeq ($(OS),Windows_NT)
@@ -25,13 +25,13 @@ PLACEHOLDER_REPORT_MD := $(REPORTS_DIR)/placeholders.md
 PLACEHOLDER_SARIF := $(REPORTS_DIR)/placeholder-audit.sarif
 PLACEHOLDER_COMMENT := $(REPORTS_DIR)/placeholder-comment.md
 PLACEHOLDER_BASE ?= $(shell \
-        if git rev-parse --verify origin/main >/dev/null 2>&1; then \
-                echo origin/main; \
-        elif git rev-parse --verify main >/dev/null 2>&1; then \
-                echo main; \
-        else \
-                echo HEAD; \
-        fi)
+	if git rev-parse --verify origin/main >/dev/null 2>&1; then \
+		echo origin/main; \
+	elif git rev-parse --verify main >/dev/null 2>&1; then \
+		echo main; \
+	else \
+		echo HEAD; \
+	fi)
 PLACEHOLDER_PATTERNS := tools/placeholder_patterns.yml
 PIP_AUDIT_REPORT := $(SECURITY_DIR)/pip-audit.json
 BANDIT_REPORT := $(SECURITY_DIR)/bandit.json
@@ -60,6 +60,9 @@ bootstrap: $(BOOTSTRAP_STAMP) ## Provision local environment with dependencies
 lint: bootstrap ## Run Ruff lint checks
 	@$(PYTHON_BIN) tools/check_makefile_tabs.py Makefile
 	@$(RUFF) check src tests scripts
+
+fix-makefile-tabs: ## Normalize Makefile recipes to start with tabs
+	@$(PYTHON) -m tools.fix_makefile_tabs
 
 lint-fix: bootstrap ## Run Ruff with autofix enabled
 	@$(RUFF) check src tests scripts --fix

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ pip install --require-hashes -r requirements-security.lock
 
 ### Otras utilidades de `make`
 - `make lint` / `make lint-fix` – Ruff.
+- `make fix-makefile-tabs` – Normaliza indentación en recetas de Makefile (tabs obligatorios).
 - `make typecheck` – mypy sobre `src/` y `tests/`.
 - `make security` – `pip-audit`, `bandit` y `trufflehog3` con `scripts/security_gate.py`.
 - `make config-validate` / `make config-dump` / `make config-docs` – gestión de configuración.
@@ -205,6 +206,7 @@ Workflows en `.github/workflows/`:
 - `security.yml`: escaneos dedicados (bandit, trufflehog, pip-audit).
 - `dependency-lock-check.yml`: valida sincronía de lockfiles.
 - `manual-lock-sync.yml`: job manual para refrescar `requirements.lock`; empuja una rama auxiliar y requiere crear el PR manualmente.
+- `fix-makefile-tabs.yml`: workflow manual que ejecuta el normalizador de Makefile y abre un PR con los cambios.
 - `placeholder-audit-pr.yml`: auditoría de placeholders estructurados (delta mode, SARIF + comentario de PR).
 - `placeholder-audit-nightly.yml`: escaneo completo diario (no bloqueante) con resumen en el job.
 - `release.yml`: empaquetado y publicación (ver [release checklist](docs/release-checklist.md)).

--- a/tests/test_fix_makefile_tabs.py
+++ b/tests/test_fix_makefile_tabs.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from tools.fix_makefile_tabs import fix_paths
+
+
+def read_lines(path: Path) -> list[str]:
+    return path.read_text(encoding="utf-8").splitlines()
+
+
+def test_fix_paths_replaces_leading_spaces(tmp_path: Path) -> None:
+    makefile = tmp_path / "Makefile"
+    makefile.write_text(
+        "target:\n"
+        "        if true; then \\\n"
+        "                echo ok; \\\n"
+        "        fi\n",
+        encoding="utf-8",
+    )
+
+    exit_code = fix_paths((makefile,), tab_size=8, check_only=False)
+
+    assert exit_code == 0
+    lines = read_lines(makefile)
+    assert lines[1].startswith("\t")
+    assert lines[2].startswith("\t")
+    assert lines[3].startswith("\t")
+
+
+def test_fix_paths_check_mode_leaves_file_unchanged(tmp_path: Path) -> None:
+    makefile = tmp_path / "Makefile"
+    original = "target:\n    echo spaced\n"
+    makefile.write_text(original, encoding="utf-8")
+
+    exit_code = fix_paths((makefile,), tab_size=8, check_only=True)
+
+    assert exit_code == 1
+    assert makefile.read_text(encoding="utf-8") == original

--- a/tools/fix_makefile_tabs.py
+++ b/tools/fix_makefile_tabs.py
@@ -1,0 +1,128 @@
+"""Normalize Makefile indentation to ensure recipes start with tabs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Sequence
+
+from tools.check_makefile_tabs import TabViolation, find_tab_violations
+
+DEFAULT_TAB_SIZE = 8
+
+
+@dataclass(frozen=True)
+class FixSummary:
+    """Structured information about fixes applied to a file."""
+
+    path: Path
+    lines: tuple[int, ...]
+
+    def to_json(self) -> str:
+        """Return a JSON representation compatible with CI tooling."""
+
+        payload = {
+            "path": self.path.as_posix(),
+            "lines": list(self.lines),
+        }
+        return json.dumps(payload, ensure_ascii=False)
+
+
+def _convert_line(line: str, tab_size: int) -> tuple[str, bool]:
+    """Convert a line to begin with tabs when it starts with spaces."""
+
+    stripped = line.lstrip()
+    if not stripped or stripped.startswith("#"):
+        return line, False
+    if line.startswith("\t"):
+        return line, False
+    if not line.startswith(" "):
+        return line, False
+
+    leading_spaces = len(line) - len(line.lstrip(" "))
+    tabs = leading_spaces // tab_size
+    remainder = leading_spaces % tab_size
+    if tabs == 0:
+        tabs = 1
+        remainder = 0
+
+    new_line = "\t" * tabs + " " * remainder + stripped
+    return new_line, new_line != line
+
+
+def _apply_fixes(
+    path: Path, lines: list[str], violations: Iterable[TabViolation], tab_size: int
+) -> FixSummary | None:
+    changed: list[int] = []
+    for violation in violations:
+        index = violation.line_number - 1
+        original = lines[index]
+        without_newline = original.rstrip("\r\n")
+        newline = original[len(without_newline) :]
+        fixed, mutated = _convert_line(without_newline, tab_size)
+        if not mutated:
+            continue
+        lines[index] = f"{fixed}{newline}"
+        changed.append(violation.line_number)
+    if not changed:
+        return None
+    return FixSummary(path=path, lines=tuple(changed))
+
+
+def fix_paths(paths: Sequence[Path], tab_size: int, check_only: bool) -> int:
+    """Normalize indentation for each provided Makefile path."""
+
+    exit_code = 0
+    for path in paths:
+        if not path.exists():
+            message = json.dumps(
+                {"path": path.as_posix(), "error": "file does not exist"}
+            )
+            raise FileNotFoundError(message)
+        content = path.read_text(encoding="utf-8")
+        lines = content.splitlines(keepends=True)
+        violations = tuple(find_tab_violations(path))
+        summary = _apply_fixes(path, lines, violations, tab_size)
+        if summary is None:
+            continue
+        if check_only:
+            exit_code = 1
+        else:
+            path.write_text("".join(lines), encoding="utf-8")
+        sys.stdout.write(f"{summary.to_json()}\n")
+    return exit_code
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        type=Path,
+        default=(Path("Makefile"),),
+        help="Makefiles to normalize.",
+    )
+    parser.add_argument(
+        "--tab-size",
+        type=int,
+        default=DEFAULT_TAB_SIZE,
+        help="Number of spaces represented by a tab when rebuilding indentation.",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Run in dry-run mode; exit with status 1 if changes are required.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    return fix_paths(tuple(args.paths), args.tab_size, args.check)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- ensure the placeholder base detection in the Makefile uses tab-prefixed lines and expose a `make fix-makefile-tabs` helper
- add `tools.fix_makefile_tabs` with automated indentation normalization, unit tests, and documentation updates
- provide a `fix-makefile-tabs.yml` workflow to manually trigger the fixer and open a pull request when changes are needed

## Testing
- make lint
- make typecheck
- make test
- .venv/bin/pip-audit -r requirements.txt --format json --output reports/security/pip-audit.json
- .venv/bin/bandit -r src scripts -c .bandit --severity-level high --confidence-level high
- .venv/bin/python scripts/run_secret_scan.py --output reports/security/trufflehog.json --severity HIGH --target . --config .gitleaks.toml
- /root/.local/share/mise/installs/go/1.24.3/bin/gitleaks detect --no-git --source . --config .gitleaks.toml --report-format json --report-path reports/security/gitleaks.json

------
https://chatgpt.com/codex/tasks/task_e_68deb07e4ea8832f94f6ef63976f6aec