### PR TITLE
Add Phase 0 inventory snapshot

### DIFF
--- a/audit/00_inventory.json
+++ b/audit/00_inventory.json
@@ -1,0 +1,368 @@
+{
+  "generated_at": "2025-10-02T19:55:47.341383+00:00",
+  "python_version": "3.12.10",
+  "top_level_inventory": {
+    ".bandit": null,
+    ".dockerignore": null,
+    ".env.example": null,
+    ".github/": [
+      "dependabot.yml",
+      "workflows"
+    ],
+    ".gitignore": null,
+    ".gitleaks.toml": null,
+    ".placeholder-audit.yaml": null,
+    "AGENTS.md": null,
+    "CHANGELOG.md": null,
+    "CONTRIBUTING.md": null,
+    "Dockerfile": null,
+    "Makefile": null,
+    "README.md": null,
+    "audit/": [
+      "00_inventory.json",
+      "00_inventory.md"
+    ],
+    "config/": [
+      "__init__.py",
+      "__pycache__",
+      "perf_thresholds.py",
+      "settings.py",
+      "sources.py",
+      "version.py"
+    ],
+    "config.toml": null,
+    "core/": [
+      "config_manager.py",
+      "config_schema.py"
+    ],
+    "data/": [
+      "dlq",
+      "logs"
+    ],
+    "docs/": [
+      "api_examples.md",
+      "collector_runbook.md",
+      "common_output_format.md",
+      "config_fields.md",
+      "database_deployment.md",
+      "faq.md",
+      "fixtures.md",
+      "operations.md",
+      "performance_baselines.md",
+      "placeholder_policy.md",
+      "release-checklist.md",
+      "release_notes.md",
+      "runbook.md",
+      "security.md"
+    ],
+    "main.py": null,
+    "news_collector_structure.py": null,
+    "noticiencias/": [
+      "__init__.py",
+      "__pycache__",
+      "config_manager.py",
+      "config_schema.py",
+      "gui_config.py"
+    ],
+    "pyproject.toml": null,
+    "reports/": [
+      ".gitkeep",
+      "ops",
+      "perf"
+    ],
+    "requirements-security.lock": null,
+    "requirements.lock": null,
+    "requirements.txt": null,
+    "run_collector.py": null,
+    "scripts/": [
+      "benchmark_canonicalize.py",
+      "bump_version.py",
+      "canonicalization_dupe_demo.py",
+      "dedupe_tuning.py",
+      "enrichment_sanity.py",
+      "evaluate_ranking.py",
+      "healthcheck.py",
+      "load_test.py",
+      "migrations",
+      "profile_pipeline.py",
+      "recluster_articles.py",
+      "replay_outage.py",
+      "reranker_distribution.py",
+      "run_secret_scan.py",
+      "score_delta.py",
+      "security_gate.py",
+      "sync_lockfiles.py",
+      "update_changelog.py",
+      "weekly_quality_report.py"
+    ],
+    "setup.py": null,
+    "src/": [
+      "__init__.py",
+      "__pycache__",
+      "collectors",
+      "contracts",
+      "enrichment",
+      "monitoring",
+      "reranker",
+      "scoring",
+      "serving",
+      "storage",
+      "utils"
+    ],
+    "tests/": [
+      "data",
+      "perf",
+      "placeholder_audit",
+      "test_async_collector_parity.py",
+      "test_cli_config.py",
+      "test_collector_pipeline_e2e.py",
+      "test_config_manager.py",
+      "test_contracts_validation.py",
+      "test_database_migrations.py",
+      "test_database_pending_articles.py",
+      "test_database_simhash_behavior.py",
+      "test_datetime_utils.py",
+      "test_dedupe_utils.py",
+      "test_enrichment_pipeline.py",
+      "test_feature_scorer_config.py",
+      "test_fix_makefile_tabs.py",
+      "test_gui_config.py",
+      "test_healthcheck.py",
+      "test_main_initialization.py",
+      "test_monitoring_anomalies.py"
+    ],
+    "tools/": [
+      "check_makefile_tabs.py",
+      "config_editor.py",
+      "fix_makefile_tabs.py",
+      "placeholder_audit.py",
+      "placeholder_patterns.yml",
+      "scan_placeholders.py"
+    ]
+  },
+  "entrypoints": {
+    "main_module": "main.py",
+    "cli": {
+      "path": "run_collector.py",
+      "help": "python run_collector.py --help"
+    },
+    "make": "See make_targets section"
+  },
+  "make_targets": [
+    {
+      "target": "bootstrap",
+      "description": "Provision local environment with dependencies"
+    },
+    {
+      "target": "lint",
+      "description": "Run Ruff lint checks"
+    },
+    {
+      "target": "fix-makefile-tabs",
+      "description": "Normalize Makefile recipes to start with tabs"
+    },
+    {
+      "target": "lint-fix",
+      "description": "Run Ruff with autofix enabled"
+    },
+    {
+      "target": "typecheck",
+      "description": "Static type checking with mypy"
+    },
+    {
+      "target": "test",
+      "description": "Execute the unit test suite with coverage reporting"
+    },
+    {
+      "target": "e2e",
+      "description": "Run end-to-end pytest suite (marked tests)"
+    },
+    {
+      "target": "perf",
+      "description": "Run performance-focused pytest suite (marked tests)"
+    },
+    {
+      "target": "security",
+      "description": "Run security and dependency scans"
+    },
+    {
+      "target": "audit-todos",
+      "description": "Run structured placeholder audit and store reports"
+    },
+    {
+      "target": "audit-todos-baseline",
+      "description": "Legacy compatibility target (structured audit owns gating now)"
+    },
+    {
+      "target": "audit-todos-check",
+      "description": "Run PR-scoped placeholder audit with SARIF + comment artifacts"
+    },
+    {
+      "target": "config-gui",
+      "description": "Launch the desktop configuration editor"
+    },
+    {
+      "target": "config-set",
+      "description": "Update configuration without opening the GUI (KEY=section.name=value)"
+    },
+    {
+      "target": "config-validate",
+      "description": "Validate active configuration sources"
+    },
+    {
+      "target": "config-dump",
+      "description": "Print the built-in default configuration"
+    },
+    {
+      "target": "config-docs",
+      "description": "Regenerate docs/config_fields.md from the schema"
+    },
+    {
+      "target": "clean",
+      "description": "Remove virtual environment and caches"
+    },
+    {
+      "target": "help",
+      "description": "Show this help message"
+    },
+    {
+      "target": "bump-version",
+      "description": "Bump project version (PART=major|minor|patch or VERSION=X.Y.Z)"
+    }
+  ],
+  "dependencies": {
+    "requirements_txt": [
+      "feedparser==6.0.12         # RSS/Atom feed parser - robusto y confiable",
+      "requests==2.32.5           # HTTP requests - est\u00e1ndar de la industria",
+      "beautifulsoup4==4.14.2     # HTML parsing para contenido adicional",
+      "lxml==6.0.2                # XML parser r\u00e1pido para feeds",
+      "nltk==3.9.2                # Natural Language Toolkit - an\u00e1lisis b\u00e1sico de texto",
+      "textblob==0.19.0           # An\u00e1lisis de sentimientos simple",
+      "python-dateutil==2.9.0.post0  # Parsing inteligente de fechas",
+      "sqlalchemy==2.0.43         # ORM potente y flexible",
+      "python-dotenv==1.1.1       # Manejo de variables de entorno",
+      "schedule==1.2.2            # Scheduling de tareas simple",
+      "click==8.3.0               # CLI interface elegante",
+      "ruamel.yaml==0.18.6        # YAML round-trip preservation para el editor de configuraci\u00f3n",
+      "tomli-w==1.0.0             # Escritura de TOML manteniendo formato estable",
+      "fastapi==0.118.0           # Framework para exponer APIs modernas",
+      "pydantic==2.11.9           # Validaci\u00f3n y serializaci\u00f3n robusta",
+      "loguru==0.7.3              # Logger moderno y bonito",
+      "pytest==8.4.2             # Framework de testing",
+      "pytest-cov==7.0.0         # Coverage de tests",
+      "scikit-learn==1.7.2       # ML algorithms b\u00e1sicos",
+      "numpy==2.3.3              # Operaciones num\u00e9ricas",
+      "httpx==0.28.1             # Compatibilidad con Starlette TestClient"
+    ],
+    "optional_security": [
+      "bandit>=1.7.9",
+      "pip-audit>=2.9.0",
+      "trufflehog3>=3.0.10"
+    ]
+  },
+  "function_index_sample": {
+    "src/collectors/__init__.py": {
+      "functions": [
+        "get_available_collector_types",
+        "create_collector_by_name"
+      ],
+      "classes": []
+    },
+    "src/collectors/async_rss_collector.py": {
+      "functions": [],
+      "classes": [
+        "AsyncRSSCollector"
+      ]
+    },
+    "src/collectors/base_collector.py": {
+      "functions": [
+        "create_collector",
+        "validate_collector_result"
+      ],
+      "classes": [
+        "BaseCollector"
+      ]
+    },
+    "src/collectors/rate_limit_utils.py": {
+      "functions": [
+        "_normalize_domain",
+        "_candidate_domains",
+        "resolve_domain_override",
+        "calculate_effective_delay"
+      ],
+      "classes": []
+    },
+    "src/collectors/rss_collector.py": {
+      "functions": [],
+      "classes": [
+        "RSSCollector"
+      ]
+    },
+    "src/contracts/collector.py": {
+      "functions": [],
+      "classes": [
+        "CollectorArticlePayload",
+        "CollectorArticleModel"
+      ]
+    },
+    "src/contracts/common.py": {
+      "functions": [],
+      "classes": [
+        "ArticleMetadata",
+        "ArticleMetadataModel"
+      ]
+    },
+    "src/contracts/enrichment.py": {
+      "functions": [],
+      "classes": [
+        "ArticleForEnrichment",
+        "ArticleEnrichment",
+        "ArticleForEnrichmentModel",
+        "ArticleEnrichmentModel"
+      ]
+    },
+    "src/contracts/scoring.py": {
+      "functions": [],
+      "classes": [
+        "ScoringComponents",
+        "ScoringComponentsModel",
+        "ScoringRequest",
+        "ScoringRequestModel"
+      ]
+    },
+    "src/enrichment/nlp_stack.py": {
+      "functions": [],
+      "classes": [
+        "NLPResult",
+        "LRUCache",
+        "ConfigurableNLPStack"
+      ]
+    }
+  },
+  "markdown_files": [
+    "CHANGELOG.md",
+    "docs/faq.md",
+    "docs/config_fields.md",
+    "docs/operations.md",
+    "docs/api_examples.md",
+    "docs/release-checklist.md",
+    "docs/placeholder_policy.md",
+    "docs/collector_runbook.md",
+    "docs/common_output_format.md",
+    "docs/performance_baselines.md",
+    "docs/release_notes.md",
+    "docs/runbook.md",
+    "docs/database_deployment.md",
+    "docs/security.md",
+    "docs/fixtures.md",
+    "tests/placeholder_audit/fixtures/doc_page.md",
+    "AGENTS.md",
+    "README.md",
+    "audit/00_inventory.md",
+    "CONTRIBUTING.md"
+  ],
+  "open_questions": [
+    "Missing: Confirm actual pytest coverage percentages (R3 requires \u226580% overall, \u226590% touched modules).",
+    "Missing: Validate whether CI enforces bandit/gitleaks/pip-audit baselines or requires manual gating."
+  ]
+}

--- a/audit/00_inventory.md
+++ b/audit/00_inventory.md
@@ -1,0 +1,46 @@
+# Noticiencias News Collector — Phase 0 Inventory
+
+## Overview
+- **Python version:** 3.12.10 (local interpreter)
+- **Top-level layout:** `.bandit`, `.github/`, `config/`, `core/`, `docs/`, `noticiencias/`, `scripts/`, `src/`, `tests/`, plus tooling such as `Makefile`, `pyproject.toml`, `requirements*.txt`, and orchestration entrypoints (`main.py`, `run_collector.py`).
+- **Key configuration:** `config.toml`, environment-specific modules under `config/`, and YAML/TOML docs in `docs/`.
+- **Data/log folders:** `data/dlq`, `data/logs` (present but empty in snapshot).
+
+## Entry Points & Tooling
+- **CLI:** `python run_collector.py --help` — orchestrates full pipeline with options for dry runs, source selection, health checks, and verbosity control.
+- **Module:** `main.NewsCollectorSystem` referenced as orchestrator in documentation.
+- **Make targets:** bootstrap, lint, lint-fix, typecheck, test, e2e, perf, security, audit-todos, audit-todos-baseline, audit-todos-check, config-gui, config-set, config-validate, config-dump, config-docs, clean, help, bump-version.
+
+## Dependencies Snapshot
+- **requirements.txt highlights:** feedparser==6.0.12, requests==2.32.5, beautifulsoup4==4.14.2, lxml==6.0.2, nltk==3.9.2, textblob==0.19.0, python-dateutil==2.9.0.post0, sqlalchemy==2.0.43, python-dotenv==1.1.1, schedule==1.2.2, click==8.3.0, ruamel.yaml==0.18.6, tomli-w==1.0.0, fastapi==0.118.0, pydantic==2.11.9, loguru==0.7.3, pytest==8.4.2.
+- **Security extras (pyproject optional):** bandit>=1.7.9, pip-audit>=2.9.0, trufflehog3>=3.0.10.
+
+## Function/Class Index (sample)
+| Module | Functions | Classes |
+| --- | --- | --- |
+| src/collectors/__init__.py | get_available_collector_types, create_collector_by_name | — |
+| src/collectors/base_collector.py | create_collector, validate_collector_result | BaseCollector |
+| src/collectors/rate_limit_utils.py | _normalize_domain, _candidate_domains, resolve_domain_override, calculate_effective_delay | — |
+| src/contracts/collector.py | — | CollectorArticlePayload, CollectorArticleModel |
+| src/enrichment/nlp_stack.py | — | NLPResult, LRUCache, ConfigurableNLPStack |
+| src/scoring/feature_scorer.py | _get_attr | FeatureWeights, FeatureBasedScorer |
+| src/serving/api.py | _decode_cursor, _encode_cursor, _extract_topics, _summarize_why_ranked, _apply_topic_filters, _build_article_payload, create_app | ArticleListParams, ArticleResponse, PaginationResponse, ArticlesEnvelope |
+| src/utils/dedupe.py | normalize_article_text, sha256_hex, simhash64, hamming_distance, duplication_confidence, generate_cluster_id | — |
+| src/utils/logger.py | get_logger, setup_logging, log_function_calls, log_memory_usage, _log_system_health | NewsCollectorLogger, CollectionSessionLogger |
+| src/utils/url_canonicalizer.py | _clean_host, _normalize_path, _filter_query_params, canonicalize_url | — |
+
+*(Full listing in `audit/00_inventory.json` → `function_index_sample`.)*
+
+## Markdown Surface Map
+CHANGELOG.md, README.md, CONTRIBUTING.md, docs/*.md (faq, operations, api_examples, collector_runbook, common_output_format, performance_baselines, release_notes, runbook, database_deployment, security, fixtures, placeholder_policy), tests/placeholder_audit/fixtures/doc_page.md, AGENTS.md.
+
+## Open Questions
+1. Missing: Confirm actual pytest coverage percentages versus R3 requirement (≥80% overall, ≥90% touched modules).
+2. Missing: Validate whether CI enforces bandit/gitleaks/pip-audit baselines or if manual gating is required.
+
+## Verification Checklist (Phase 0)
+- Ruff lint (`ruff check src tests scripts`) — pass.
+- Mypy type check (`mypy src tests`) — pass (with existing `annotation-unchecked` note).
+- Bandit SAST (`bandit -ll -r src scripts`) — **FAIL**: flagged high-severity MD5 usage in `src/utils/dedupe.py:36`; remediation backlog item.
+- Gitleaks secret scan — **NOT RUN**: binary unavailable in container (`pip install gitleaks` has no distribution); document as tooling gap.
+- Pip-audit (`pip-audit -r requirements.txt`) — **INCOMPLETE**: command hung while building isolated wheels (likely due to heavy packages such as `lxml`); aborted after extended wait.


### PR DESCRIPTION
## Summary
- add Phase 0 inventory deliverables (`audit/00_inventory.md` and `audit/00_inventory.json`) capturing layout, entry points, dependencies, and markdown surfaces
- document verification status and outstanding open questions for coverage and security tooling gaps

## Testing
- `ruff check src tests scripts`
- `mypy src tests`
- `bandit -ll -r src scripts` *(fails: high-severity MD5 usage in src/utils/dedupe.py:36)*
- `gitleaks detect --no-git -v` *(tool unavailable in environment)*
- `pip-audit -r requirements.txt` *(hung during wheel build; aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68ded694a184832f8d973845f2a09dd5