### PR TITLE
Add docs-code audit report and update troubleshooting references

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Ajustar volumenes para `data/` si se desea persistencia.
 | `scripts/enrichment_sanity.py` | Sanity check de enriquecimiento (idioma, entidades, sentimiento) | `python scripts/enrichment_sanity.py data/exports/batch.json` |
 | `scripts/weekly_quality_report.py` | Genera reporte semanal (monitoring.v1) | `python scripts/weekly_quality_report.py tests/data/monitoring/outage_replay.json` |
 | `scripts/replay_outage.py` | Reproduce incidentes históricos con canarios | `python scripts/replay_outage.py tests/data/monitoring/outage_replay.json` |
-| `scripts/healthcheck.py` | Healthcheck CLI standalone | `python scripts/healthcheck.py --max-ingest-minutes 30` |
+| `scripts/healthcheck.py` | Healthcheck CLI standalone | `python -m scripts.healthcheck --max-ingest-minutes 30` |
 | `scripts/run_secret_scan.py` | Ejecución directa de trufflehog3 | `python scripts/run_secret_scan.py --target .` |
 
 Más utilidades en `scripts/` (dedupe tuning, benchmarks, perfiles de pipeline) documentadas en [docs/operations.md](docs/operations.md).

--- a/audit/01_docs_code_diff.md
+++ b/audit/01_docs_code_diff.md
@@ -1,0 +1,24 @@
+# 01 — Docs ↔ Code Consistency Gap Report
+
+## Scope & Method
+- Scanned `README.md` and `docs/*.md` for CLI commands, configuration references, and operational runbooks.
+- Queried the runtime CLI entry points (`python run_collector.py --help`, `python -m noticiencias.config_manager --help`) to confirm published flags.
+- Inspected configuration sources (`config.toml`, `config/settings.py`, `config/sources.py`) to verify documented paths and keys.
+- Executed documented scripts where possible to validate invocation instructions.
+
+## Findings
+| ID | Documentation | Documented Claim | Reality | Impact | Proposed Fix |
+| --- | --- | --- | --- | --- | --- |
+| D1 | `docs/faq.md` (429 section) | Mentions tuning `config/sources.yaml` / `config/rate_limits.yaml`. | Project ships Python modules (`config/sources.py`) and TOML config (`config.toml`), no YAML files exist. | Operators chasing YAML files cannot remediate rate-limit incidents. | Update references to `config/sources.py` and `[rate_limiting]` in `config.toml`. |
+| D2 | `docs/faq.md` (429 section) | Advises running `python scripts/rate_limit_probe.py --source <id>`. | Script `scripts/rate_limit_probe.py` is absent; available utility is `scripts/load_test.py`. | Troubleshooting playbook cannot be executed as written. | Swap to `python -m scripts.load_test --num-sources 1 --concurrency 1` guidance. |
+| D3 | `docs/faq.md` (ModuleNotFoundError section) | Points to `config/enrichment.yaml` for model paths. | Enrichment configuration lives under `[enrichment.models]` in `config.toml`. | Engineers will edit nonexistent YAML and miss the real source of truth. | Reference `config.toml` enrichment section instead. |
+| D4 | `README.md` (scripts table) | Suggests `python scripts/healthcheck.py --max-ingest-minutes 30`. | Direct execution fails (`ModuleNotFoundError: No module named 'src'`) because Python omits the project root from `sys.path`. | Runbook automation and manual invocations fail unless engineers debug path issues. | Recommend `python -m scripts.healthcheck --max-ingest-minutes 30`, which succeeds. |
+
+## Command Verification
+- `python run_collector.py --help` ✅
+- `python -m noticiencias.config_manager --help` ✅ (emits runpy warning; functionality OK)
+- `python scripts/healthcheck.py --help` ❌ (`ModuleNotFoundError: No module named 'src'`)
+- `python -m scripts.healthcheck --help` ✅
+
+## Next Steps
+Apply the documentation edits captured in `audit/01_docs_fixes.patch` and ensure future CLI documentation uses module invocations for scripts that rely on project-relative imports.

--- a/audit/01_docs_fixes.patch
+++ b/audit/01_docs_fixes.patch
@@ -1,0 +1,41 @@
+diff --git a/README.md b/README.md
+index 731ab52..d6301c7 100644
+--- a/README.md
++++ b/README.md
+@@ -157,7 +157,7 @@ Ajustar volumenes para `data/` si se desea persistencia.
+ | `scripts/enrichment_sanity.py` | Sanity check de enriquecimiento (idioma, entidades, sentimiento) | `python scripts/enrichment_sanity.py data/exports/batch.json` |
+ | `scripts/weekly_quality_report.py` | Genera reporte semanal (monitoring.v1) | `python scripts/weekly_quality_report.py tests/data/monitoring/outage_replay.json` |
+ | `scripts/replay_outage.py` | Reproduce incidentes históricos con canarios | `python scripts/replay_outage.py tests/data/monitoring/outage_replay.json` |
+-| `scripts/healthcheck.py` | Healthcheck CLI standalone | `python scripts/healthcheck.py --max-ingest-minutes 30` |
++| `scripts/healthcheck.py` | Healthcheck CLI standalone | `python -m scripts.healthcheck --max-ingest-minutes 30` |
+ | `scripts/run_secret_scan.py` | Ejecución directa de trufflehog3 | `python scripts/run_secret_scan.py --target .` |
+ 
+ Más utilidades en `scripts/` (dedupe tuning, benchmarks, perfiles de pipeline) documentadas en [docs/operations.md](docs/operations.md).
+diff --git a/docs/faq.md b/docs/faq.md
+index ffcc37d..891a7e3 100644
+--- a/docs/faq.md
++++ b/docs/faq.md
+@@ -12,19 +12,19 @@ Cuando la tubería falla, comienza con estos síntomas comunes antes de escalar
+   - Si necesitas concurrencia, cambia a Postgres siguiendo las instrucciones del [Runbook Operacional](runbook.md#operations-runbook).
+ 
+ ## Error: `429 Too Many Requests`
+-- **Contexto típico**: configuraciones agresivas en `config/sources.yaml` o `config/rate_limits.yaml`.
++- **Contexto típico**: configuraciones agresivas en `config/sources.py` o sobrescrituras en `[rate_limiting]` dentro de `config.toml`.
+ - **Diagnóstico rápido**:
+   - Consulta los logs estructurados (`event: rate_limit.backoff`) para identificar la fuente.
+-  - Ejecuta `python scripts/rate_limit_probe.py --source <id>` para validar la nueva ventana.
++  - Ejecuta `python -m scripts.load_test --num-sources 1 --concurrency 1` para observar latencias y reintentos con la fuente problemática.
+ - **Resolución**:
+-  - Incrementa `min_delay_seconds` para la fuente afectada y, si aplica, ajusta `RATE_LIMITING_CONFIG["domain_overrides"]`.
++  - Ajusta `domain_overrides` en `[rate_limiting]` (`config.toml`) o los parámetros de la fuente en `config/sources.py`, y reinicia el collector para aplicar los cambios.
+   - Repite la ejecución con `python run_collector.py --dry-run --sources <id>` y verifica que el Runbook no reporte nuevas alertas.
+ 
+ ## Error: `ModuleNotFoundError` para modelos de enriquecimiento
+ - **Contexto típico**: entorno virtual sin dependencias opcionales o modelos locales eliminados.
+ - **Diagnóstico rápido**:
+   - Comprueba dependencias con `pip install --require-hashes -r requirements.lock`.
+-  - Verifica la caché de modelos (`.cache/noticiencias/models/`) y las rutas esperadas en `config/enrichment.yaml`.
++  - Verifica la caché de modelos (`.cache/noticiencias/models/`) y las rutas esperadas bajo `[enrichment.models]` en `config.toml`.
+ - **Resolución**:
+   - Ejecuta `make bootstrap` para reinstalar dependencias y descargar modelos declarados en el `Makefile`.
+   - Si necesitas regenerar embeddings, sigue la sección "Enrichment drift" del [Runbook Operacional](runbook.md#2-dedupe-drift).

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -12,19 +12,19 @@ Cuando la tubería falla, comienza con estos síntomas comunes antes de escalar 
   - Si necesitas concurrencia, cambia a Postgres siguiendo las instrucciones del [Runbook Operacional](runbook.md#operations-runbook).
 
 ## Error: `429 Too Many Requests`
-- **Contexto típico**: configuraciones agresivas en `config/sources.yaml` o `config/rate_limits.yaml`.
+- **Contexto típico**: configuraciones agresivas en `config/sources.py` o sobrescrituras en `[rate_limiting]` dentro de `config.toml`.
 - **Diagnóstico rápido**:
   - Consulta los logs estructurados (`event: rate_limit.backoff`) para identificar la fuente.
-  - Ejecuta `python scripts/rate_limit_probe.py --source <id>` para validar la nueva ventana.
+  - Ejecuta `python -m scripts.load_test --num-sources 1 --concurrency 1` para observar latencias y reintentos con la fuente problemática.
 - **Resolución**:
-  - Incrementa `min_delay_seconds` para la fuente afectada y, si aplica, ajusta `RATE_LIMITING_CONFIG["domain_overrides"]`.
+  - Ajusta `domain_overrides` en `[rate_limiting]` (`config.toml`) o los parámetros de la fuente en `config/sources.py`, y reinicia el collector para aplicar los cambios.
   - Repite la ejecución con `python run_collector.py --dry-run --sources <id>` y verifica que el Runbook no reporte nuevas alertas.
 
 ## Error: `ModuleNotFoundError` para modelos de enriquecimiento
 - **Contexto típico**: entorno virtual sin dependencias opcionales o modelos locales eliminados.
 - **Diagnóstico rápido**:
   - Comprueba dependencias con `pip install --require-hashes -r requirements.lock`.
-  - Verifica la caché de modelos (`.cache/noticiencias/models/`) y las rutas esperadas en `config/enrichment.yaml`.
+  - Verifica la caché de modelos (`.cache/noticiencias/models/`) y las rutas esperadas bajo `[enrichment.models]` en `config.toml`.
 - **Resolución**:
   - Ejecuta `make bootstrap` para reinstalar dependencias y descargar modelos declarados en el `Makefile`.
   - Si necesitas regenerar embeddings, sigue la sección "Enrichment drift" del [Runbook Operacional](runbook.md#2-dedupe-drift).


### PR DESCRIPTION
## Summary
- add the docs vs. code gap report for Phase 1 under `audit/`
- capture the proposed documentation updates in `audit/01_docs_fixes.patch`
- refresh README/FAQ guidance so operators use existing Python modules and configuration locations

## Testing
- python run_collector.py --help
- python -m noticiencias.config_manager --help
- python -m scripts.healthcheck --help

------
https://chatgpt.com/codex/tasks/task_e_68dee99445c4832fa20e519d728555f5