### PR TITLE
Add security gate and phase 7 security audit

### DIFF
--- a/.github/workflows/audit-security.yml
+++ b/.github/workflows/audit-security.yml
@@ -1,0 +1,72 @@
+name: Security gate
+
+on:
+  push:
+    branches:
+      - main
+      - work
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  security:
+    name: Static & secret scans
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+          cache-dependency-path: |
+            requirements.lock
+            requirements-security.lock
+
+      - name: Install security dependencies
+        run: |
+          set -euo pipefail
+          python -m pip install --upgrade pip
+          pip install --require-hashes -r requirements-security.lock
+
+      - name: Prepare reports directory
+        run: mkdir -p reports/security
+
+      - name: Install gitleaks
+        run: |
+          set -euo pipefail
+          version=8.18.0
+          curl -sSL -o /tmp/gitleaks.tar.gz "https://github.com/gitleaks/gitleaks/releases/download/v${version}/gitleaks_${version}_linux_x64.tar.gz"
+          tar -xzf /tmp/gitleaks.tar.gz -C /tmp gitleaks
+          install /tmp/gitleaks /usr/local/bin/gitleaks
+
+      - name: Run Bandit
+        run: |
+          set -euo pipefail
+          bandit -ll -r src core scripts noticiencias run_collector.py main.py -v -f json -o reports/security/bandit.json
+
+      - name: Run Gitleaks
+        run: |
+          set -euo pipefail
+          gitleaks detect --source . --no-banner --redact --config=.gitleaks.toml --report-format json --report-path reports/security/gitleaks_report.json
+
+      - name: Run pip-audit
+        run: |
+          set -euo pipefail
+          pip-audit -r requirements.lock -r requirements-security.lock \
+            --ignore-vuln GHSA-q2x7-8rv6-6q7h \
+            --ignore-vuln GHSA-gmj6-6f8f-6699 \
+            --ignore-vuln GHSA-cpwx-vrp4-4pq7 \
+            -f json -o reports/security/pip_audit.json
+
+      - name: Upload security reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: security-reports
+          path: reports/security
+          if-no-files-found: warn

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -13,7 +13,10 @@ regexes = [
   '''dummy(_|-)secret''',
   '''test(_|-)api(_|-)key''',
 ]
-commits = []
+commits = [
+  "9c9bdf23e48ba2d0154d59404eac61b29ce24a40",
+  "bce631a5ec1c61accc83700ae5ed47e84f1ec832",
+]
 
 [[rules]]
 id = "generic-api-key"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM python:3.11-slim AS runtime
+FROM python:3.11.9-slim AS runtime
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
@@ -12,8 +12,16 @@ COPY requirements.lock ./requirements.lock
 RUN pip install --upgrade pip \
     && pip install --require-hashes -r requirements.lock
 
+# Create unprivileged runtime user after dependencies are baked in
+RUN groupadd --system app \
+    && useradd --system --create-home --home-dir /home/app --gid app app
+
 # Copiamos el código fuente
 COPY . .
+
+RUN chown -R app:app /app
+
+USER app
 
 ENV PYTHONPATH=/app/src
 

--- a/README.md
+++ b/README.md
@@ -232,8 +232,9 @@ Workflows en `.github/workflows/`:
 ## Seguridad
 - Secrets siempre via variables de entorno (`NOTICIENCIAS__DATABASE__PASSWORD`, etc.).
 - Ejecutar `make security` antes de merges críticos.
+- Workflow [`Security gate`](.github/workflows/audit-security.yml) ejecuta Bandit, Gitleaks y `pip-audit` en cada push/PR; mantenerlo en verde es requisito para mergear.
 - `scripts/run_secret_scan.py` usa `trufflehog3` con patrones definidos en `tools/placeholder_patterns.yml`.
-- Revisar [docs/security.md](docs/security.md) para políticas de acceso y rotación.
+- Revisar [docs/security.md](docs/security.md) para políticas de acceso, rotación y respuesta a findings.
 
 ## Troubleshooting & FAQ
 - Sección rápida en [docs/faq.md](docs/faq.md).

--- a/audit/07_asvs_checklist.md
+++ b/audit/07_asvs_checklist.md
@@ -1,0 +1,20 @@
+# Phase 7 — OWASP ASVS Checklist
+
+## Scope
+Assessment targets the headless CLI/data-pipeline deployment model for Noticiencias, covering configuration management, containerization, and CI security automation. Controls unrelated to interactive authentication or session management are out of scope.
+
+## Control Status
+| ASVS Control | Description (abridged) | Status | Evidence | Follow-up |
+| --- | --- | --- | --- | --- |
+| V1.1.1 | Document security architecture, components, and trust boundaries. | ✅ Pass | `AGENTS.md` and refreshed security documentation (`docs/security.md`). | Keep diagrams updated when new pipeline stages ship. |
+| V1.2.4 | Ensure automated security testing is integrated into CI/CD. | ✅ Pass | New `audit-security` workflow runs Bandit, Gitleaks, and pip-audit on push/PR. | Monitor runtime to keep job under 5 minutes. |
+| V4.1.3 | Enforce least-privilege execution environments. | ✅ Pass | Dockerfile now creates a non-root `app` user before running the collector. | Extend principle to Kubernetes manifests (Missing). |
+| V5.1.4 | Validate and sanitize all configuration input. | ✅ Pass | `noticiencias.config_manager` serializes via Pydantic models and drops unset/None values. | Add regression tests for `_serialize_for_toml`. |
+| V10.2.1 | Perform static code analysis on all code prior to release. | ✅ Pass | Bandit gate enforced in CI; weekly scheduled scan remains active. | Consider enabling SARIF uploads for code scanning dashboard. |
+| V10.4.2 | Maintain a software composition analysis (SCA) process. | ✅ Pass | pip-audit executes on lockfiles (three GHSA IDs suppressed pending upstream `trufflehog3` fix); Dependabot already enabled. | Automate SBOM publication via CycloneDX output (Missing). |
+| V13.2.1 | Protect sensitive secrets and keys from source control. | ⚠️ Partial | `.gitleaks.toml` allowlists documented false positives; no secrets in current tree. | Add pre-commit secret hook to shorten feedback loop. |
+| V14.2.3 | Ensure secure configuration defaults for all deployments. | ✅ Pass | Hash-locked dependency installs and documented security defaults in README/`docs/security.md`. | Document minimum container runtime permissions (Missing). |
+
+## Open Questions
+- Missing: Confirm Kubernetes/job runner manifests drop root capabilities to extend least privilege beyond the container image.
+- Missing: Decide on artifact signing strategy (e.g., Cosign) and integrate with release pipeline.

--- a/audit/07_security_report.md
+++ b/audit/07_security_report.md
@@ -1,0 +1,41 @@
+# Phase 7 — Security & Attack Surface
+
+## Summary
+- Executed the mandated Bandit, Gitleaks, and pip-audit sweeps with high verbosity and stored JSON artifacts under `reports/security/`.
+- Verified the codebase avoids `shell=True`, `eval`, or `exec` patterns and that external inputs are validated via existing schema tooling.
+- Hardened the container image to run as a non-root user on a pinned Python 3.11.9 base and ensured dependency installs remain hash-locked.
+- Added an always-on GitHub Actions security gate so pull requests cannot merge while static analysis or secret scans fail.
+- Documented the residual false-positive secret detections and mapped mitigations against OWASP ASVS controls for the CLI/data pipeline.
+
+## Tooling Results
+| Tool | Command | Outcome | Evidence |
+| --- | --- | --- | --- |
+| Bandit | `bandit -ll -r src core scripts noticiencias run_collector.py main.py -v -f json -o reports/security/bandit.json` | ✅ No issues identified | `reports/security/bandit.json` and console summary (chunk `f98d80`). |
+| Gitleaks | `gitleaks detect --source . --no-banner --redact --config=.gitleaks.toml --report-format json --report-path reports/security/gitleaks_report.json` | ⚠️ Legacy commits surface three generic token false positives; allow-listed in `.gitleaks.toml`. | `reports/security/gitleaks_report.json`. |
+| pip-audit | `pip-audit -r requirements.lock -r requirements-security.lock --ignore-vuln GHSA-q2x7-8rv6-6q7h --ignore-vuln GHSA-gmj6-6f8f-6699 --ignore-vuln GHSA-cpwx-vrp4-4pq7 -f json -o reports/security/pip_audit.json` | ✅ No unmitigated vulnerabilities reported (accepted risk tracked as R-07-004). | `reports/security/pip_audit.json`. |
+
+> Note: `pip-audit` fails when pointed at `requirements.txt` because the manifest contains hashed dependencies without explicit hashes for transient wheels (e.g., `feedparser==6.0.12`). Using the compiled lockfiles keeps the scan reproducible while satisfying the `--require-hashes` policy enforced in CI.
+
+## Risk Register
+| ID | Risk | Severity | Status | Mitigation |
+| --- | --- | --- | --- | --- |
+| R-07-001 | Container image previously ran as `root`, increasing privilege escalation blast radius. | Medium | **Mitigated** | Dockerfile now creates and switches to `app` user after dependency installation while keeping hash-locked installs. |
+| R-07-002 | Gitleaks flags `ENRICHMENT_MODEL_KEY` enumerations and TOML serialization helpers as generic tokens in historic commits. | Low | **Accepted (documented)** | Added offending commits to `.gitleaks.toml` allowlist and confirmed no secrets exist in the current tree; keep monitoring new detections. |
+| R-07-003 | Dependency drift may reintroduce CVEs between scheduled scans. | Medium | **Mitigated** | Introduced push/PR security gate workflow executing Bandit, Gitleaks, and pip-audit on every change; scheduled weekly job remains as secondary net. |
+| R-07-004 | `trufflehog3==3.0.10` pins `jinja2==3.1.4`, which carries GHSA-q2x7-8rv6-6q7h / GHSA-gmj6-6f8f-6699 / GHSA-cpwx-vrp4-4pq7 advisories. | Medium | **Accepted (compensating controls)** | No patched trufflehog3 release exists yet; CI pip-audit run ignores the three GHSA identifiers and risk is tracked here until upstream relaxes the pin or we replace the scanner. |
+
+## Hardening Notes
+- Reviewed Dockerfile for secret leakage, cache busting, and reproducibility. The new image pins `python:3.11.9-slim`, uses non-root execution, and preserves `PYTHONPATH=/app/src` for runtime. No build-time secrets are cached.
+- Repository search confirmed absence of `shell=True`, dynamic `eval`, or `exec` usage in production code paths.
+- Configuration updates continue to flow through `noticiencias.config_manager.Config` models, which enforce type validation and drop unset fields before serialization, preventing injection of unvalidated values into TOML outputs.
+
+## OWASP ASVS Mapping Snapshot
+Detailed control-by-control status lives in [`audit/07_asvs_checklist.md`](07_asvs_checklist.md). Highlights:
+- **V1 Architecture**: Threat-aware documentation and CI guardrails keep the pipeline inventory current.
+- **V10 Malicious Code**: Bandit, pip-audit, and gitleaks now gate merges for static analysis coverage.
+- **V14 Configuration**: Hash-locked dependency installation and config schema validation prevent insecure defaults from shipping.
+
+## Next Steps
+1. Extend `.gitleaks.toml` regex allowlists if future audit documents enumerate placeholder secrets to avoid recurring false positives.
+2. Add integration tests covering configuration write paths to ensure TOML serialization stays guarded against injection attacks.
+3. Evaluate container image signing (e.g., Cosign) once the CI gate has stabilized to guarantee artifact provenance downstream.


### PR DESCRIPTION
## Summary
- add a security gate workflow that runs bandit, gitleaks, and pip-audit on every push/PR and stores JSON artifacts
- document the Phase 7 security assessment, OWASP ASVS mapping, and accepted scanner allowlists
- harden the Dockerfile to use a non-root app user and update README/docs with new security automation guidance

## Testing
- bandit -ll -r src core scripts noticiencias run_collector.py main.py -v
- gitleaks detect --source . --no-banner --redact --config=.gitleaks.toml --report-format json --report-path reports/security/gitleaks_report.json
- pip-audit -r requirements.lock -r requirements-security.lock --ignore-vuln GHSA-q2x7-8rv6-6q7h --ignore-vuln GHSA-gmj6-6f8f-6699 --ignore-vuln GHSA-cpwx-vrp4-4pq7 --progress-spinner off --format columns

------
https://chatgpt.com/codex/tasks/task_e_68df2e1ebfe8832fb1ba175bbf18ce51