### PR TITLE
Fix Jinja2 pin for trufflehog bootstrap

### DIFF
--- a/requirements-security.lock
+++ b/requirements-security.lock
@@ -131,8 +131,9 @@ idna==3.10 \
     --hash=sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9 \
     --hash=sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3
     # via requests
-jinja2==3.1.6 \
-    --hash=sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67
+jinja2==3.1.4 \
+    --hash=sha256:bc5dd2abb727a5319567b7a813e6a2e7318c39f4f487cfe6c89c6f9c7d25197d \
+    --hash=sha256:4a3aee7acbbe7303aede8e9648d13b8bf88a429282aa6122a993f0ac800cb369
     # via trufflehog3
 license-expression==30.4.4 \
     --hash=sha256:421788fdcadb41f049d2dc934ce666626265aeccefddd25e162a26f23bcbf8a4 \


### PR DESCRIPTION
## Summary
- realign the security lockfile to pin jinja2==3.1.4 so trufflehog3 can install during bootstrap
- add the appropriate wheel and sdist hashes for the restored pin

## Testing
- make bootstrap

------
https://chatgpt.com/codex/tasks/task_e_68dfd4eaf3d0832f85dbcbebb1bde182