### PR TITLE
Update canonicalization cache config documentation

### DIFF
--- a/docs/config_fields.md
+++ b/docs/config_fields.md
@@ -31,7 +31,7 @@
 | collection.max_articles_per_source | int | 50 | Cap on articles per source per run. |  |  |
 | collection.recent_days_threshold | int | 7 | Number of trailing days considered 'recent'. |  |  |
 | collection.user_agent | str | "NoticienciasBot/1.0 (+https://noticiencias.com)" | HTTP User-Agent header sent to providers. |  |  |
-| collection.canonicalization_cache_size | int | 2048 | LRU cache size for canonical URLs (0 disables caching). |  |  |
+| collection.canonicalization_cache_size | int | 2048 | LRU cache size for canonical URLs; set to 0 to disable caching. |  |  |
 | rate_limiting | RateLimitingConfig |  |  |  |  |
 | rate_limiting.delay_between_requests_seconds | float | 1.0 | Base delay enforced between requests to the same source. |  |  |
 | rate_limiting.domain_default_delay_seconds | float | 1.0 | Fallback delay applied when a domain has no override. |  |  |


### PR DESCRIPTION
## Summary
- regenerate docs/config_fields.md from the schema
- clarify that setting collection.canonicalization_cache_size to 0 disables caching

## Testing
- not run (docs-only change)


------
https://chatgpt.com/codex/tasks/task_e_68dfd889c5e0832f9c894e220121897c