### PR TITLE
Add tooling to publish audit findings as GitHub issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: bootstrap lint lint-fix fix-makefile-tabs type typecheck test e2e perf audit security build clean help bump-version audit-todos audit-todos-baseline audit-todos-check docs-api docs format
+.PHONY: bootstrap lint lint-fix fix-makefile-tabs type typecheck test e2e perf audit security build clean help bump-version audit-todos audit-todos-baseline audit-todos-check docs-api docs format audit-issues
 
 VENV ?= .venv
 ifeq ($(OS),Windows_NT)
@@ -46,6 +46,7 @@ BOOTSTRAP_STAMP := $(VENV)/.bootstrap-complete
 CONFIG_FILE ?= $(CURDIR)/config.toml
 KEY ?=
 EXTRA ?=
+AUDIT_ISSUES_FLAGS ?=
 
 .DEFAULT_GOAL := help
 
@@ -113,6 +114,9 @@ security: bootstrap ## Run security and dependency scans
 	@echo "[security] Running trufflehog3"
 	@$(PYTHON) scripts/run_secret_scan.py --output $(TRUFFLEHOG_REPORT) --severity HIGH --target . --config .gitleaks.toml
 	@$(PYTHON) scripts/security_gate.py trufflehog $(TRUFFLEHOG_REPORT) --severity HIGH --status $(SECURITY_STATUS)
+
+audit-issues: ## Create GitHub issues for each markdown audit finding (AUDIT_ISSUES_FLAGS=-n for dry-run)
+	@tools/audit_to_issues.sh $(AUDIT_ISSUES_FLAGS)
 
 build: bootstrap ## Produce a wheel artifact in dist/ using pinned dependencies
 	@rm -rf dist

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ pip install --require-hashes -r requirements-security.lock
 - `make docs` / `make docs-api` – Regenera la documentación de API con `pdoc`.
 - `make security` – `pip-audit`, `bandit` y `trufflehog3` con `scripts/security_gate.py`.
 - `make audit` – alias del objetivo anterior, usado en CI para auditorías de supply chain.
+- `make audit-issues` – crea issues en GitHub a partir de `audit/*.md` (ver [docs/tools_audit_issues.md](docs/tools_audit_issues.md)).
 - `make build` – genera un wheel reproducible en `dist/` usando pines.
 - `make config-validate` / `make config-dump` / `make config-docs` – gestión de configuración.
 - `make config-gui` – lanza el editor gráfico (requiere servidor X).

--- a/docs/tools_audit_issues.md
+++ b/docs/tools_audit_issues.md
@@ -1,0 +1,43 @@
+# Audit Issue Creation Tool
+
+The `tools/audit_to_issues.sh` helper converts each `./audit/*.md` file into a GitHub issue so audit findings can be triaged inside the repository backlog.
+
+## Prerequisites
+- [GitHub CLI (`gh`)](https://cli.github.com/) installed and authenticated (`gh auth login`).
+- `GH_TOKEN` exported in the shell. The token must grant `repo` scope for private repositories or `public_repo` for public repositories so the CLI can create issues on your behalf.
+- Network connectivity to GitHub's API.
+
+## Usage
+```bash
+# Dry-run: show the issue creation commands
+make audit-issues AUDIT_ISSUES_FLAGS="-n"
+
+# Create the issues in the current repository
+make audit-issues
+```
+
+Behind the scenes the Makefile target calls:
+```bash
+./tools/audit_to_issues.sh [-n] [-- <additional gh issue create args>]
+```
+
+Each markdown file generates one issue with:
+- Title: `Audit: <filename>`
+- Labels: `audit,triage`
+- Body: the line `See <path> for details.` followed by the file content.
+
+Use the `--` separator to pass extra options directly to `gh issue create`, for example to target another repository:
+```bash
+./tools/audit_to_issues.sh -n -- --repo org/project --assignee your-user
+```
+
+## Configuration
+| Name | Type | Default | Required | Description |
+| --- | --- | --- | --- | --- |
+| `GH_TOKEN` | string | _none_ | Yes | Personal access token used by `gh` to authenticate issue creation. |
+| `AUDIT_ISSUES_FLAGS` | string | _empty_ | No | Optional Makefile variable forwarded to the script (e.g., `-n` for dry-run or `-- --repo org/project`). |
+
+## Operational Notes
+- The script exits early when no `./audit/*.md` files are present.
+- Dry-run mode prints the exact `gh issue create` commands without executing them so you can review the payload first.
+- Temporary files containing issue bodies are removed after each iteration.

--- a/tools/audit_to_issues.sh
+++ b/tools/audit_to_issues.sh
@@ -1,0 +1,91 @@
+#!/bin/sh
+set -eu
+
+usage() {
+    cat <<'USAGE'
+Usage: audit_to_issues.sh [-n] [-- <gh issue create args...>]
+
+Create one GitHub issue per ./audit/*.md file with labels "audit,triage".
+
+Options:
+  -n    Dry-run; print gh commands without executing them.
+  -h    Show this help message.
+
+Any additional arguments provided after "--" are forwarded to "gh issue create".
+USAGE
+}
+
+DRY_RUN=0
+PASSTHRU_ARGS=""
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        -n)
+            DRY_RUN=1
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        --)
+            shift
+            PASSTHRU_ARGS="$*"
+            break
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            usage >&2
+            exit 1
+            ;;
+    esac
+done
+
+if ! command -v gh >/dev/null 2>&1; then
+    echo "Error: gh CLI is required but not found in PATH." >&2
+    exit 1
+fi
+
+if [ "${GH_TOKEN:-}" = "" ]; then
+    echo "Error: GH_TOKEN environment variable must be set." >&2
+    exit 1
+fi
+
+set -- ./audit/*.md
+if [ "$1" = "./audit/*.md" ] && [ ! -e "$1" ]; then
+    echo "No audit markdown files found in ./audit." >&2
+    exit 0
+fi
+
+for FILE in "$@"; do
+    if [ ! -f "$FILE" ]; then
+        continue
+    fi
+
+    BASENAME=$(basename "$FILE")
+    TITLE="Audit: $BASENAME"
+    BODY_FILE=$(mktemp)
+
+    {
+        printf 'See `%s` for details.\n\n' "$FILE"
+        cat "$FILE"
+    } >"$BODY_FILE"
+
+    if [ "$DRY_RUN" -eq 1 ]; then
+        printf 'gh issue create --title %s --label %s --body-file %s' \
+            "'${TITLE}'" "'audit,triage'" "'${BODY_FILE}'"
+        if [ -n "$PASSTHRU_ARGS" ]; then
+            printf ' %s' "$PASSTHRU_ARGS"
+        fi
+        printf '\n'
+    else
+        if [ -n "$PASSTHRU_ARGS" ]; then
+            # shellcheck disable=SC2086
+            gh issue create --title "$TITLE" --label "audit,triage" --body-file "$BODY_FILE" $PASSTHRU_ARGS
+        else
+            gh issue create --title "$TITLE" --label "audit,triage" --body-file "$BODY_FILE"
+        fi
+    fi
+
+    rm -f "$BODY_FILE"
+done


### PR DESCRIPTION
## Summary
- add a POSIX shell helper that converts each `audit/*.md` file into a `gh issue create` call with the expected title, labels, and body payload
- wire the helper into the Makefile via an `audit-issues` target with configurable flags and document the workflow in `docs/tools_audit_issues.md`
- update the README to reference the new automation entry point

## Testing
- make bootstrap
- .venv/bin/ruff check tools
- .venv/bin/black --check src tests scripts
- .venv/bin/isort --check-only src tests scripts *(fails: pre-existing import order issues across multiple test modules)*
- .venv/bin/mypy --config-file=pyproject.toml scripts/generate_api_docs.py src/utils/logger.py src/utils/url_canonicalizer.py
- .venv/bin/pytest --cov=src *(fails: perf expectation in tests/perf/test_async_collector_perf.py::test_async_collector_outperforms_sync)*
- .venv/bin/bandit -ll -r src scripts
- /tmp/gitleaks detect --no-banner --redact --source .
- .venv/bin/pip-audit
- python - <<'PY' ... (local markdown link validation)


------
https://chatgpt.com/codex/tasks/task_e_68e0038e499c832fb709681160532d10