### PR TITLE
Add config precedence matrix tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,13 @@ pip install --require-hashes -r requirements-security.lock
 3. **Archivo `.env`** contiguo (`NOTICIENCIAS__…=valor`).
 4. **Variables de entorno** con prefijo `NOTICIENCIAS__` (último gana).
 
+| Capa | Entrada de ejemplo | `app.environment` | `collection.async_enabled` | `rate_limiting.max_retries` |
+| --- | --- | --- | --- | --- |
+| Defaults (`DEFAULT_CONFIG`) | _sin overrides_ | `development` | `false` | `3` |
+| `config.toml` | `[app]\nenvironment = "staging"<br>[collection]\nasync_enabled = true<br>[rate_limiting]\nmax_retries = 7` | `staging` | `true` | `7` |
+| `.env` | `NOTICIENCIAS__APP__ENVIRONMENT=production`<br>`NOTICIENCIAS__COLLECTION__ASYNC_ENABLED=false`<br>`NOTICIENCIAS__RATE_LIMITING__MAX_RETRIES=9` | `production` | `false` | `9` |
+| Entorno de proceso | `NOTICIENCIAS__APP__ENVIRONMENT=test` | `test` | `false` | `9` |
+
 Ejemplo de sobrescritura anidada:
 ```bash
 export NOTICIENCIAS__DATABASE__DRIVER=postgresql

--- a/noticiencias/config_manager.py
+++ b/noticiencias/config_manager.py
@@ -337,7 +337,7 @@ def load_config(
 
     config_path = path if path else _default_paths()[0]
     env_path = _detect_env_path(config_path)
-    runtime_env = environ or os.environ
+    runtime_env = os.environ if environ is None else environ
 
     defaults = DEFAULT_CONFIG.model_dump(mode="python")
     merged = _deepcopy_mapping(defaults)

--- a/noticiencias/gui_config.py
+++ b/noticiencias/gui_config.py
@@ -556,7 +556,7 @@ def main(path: str | None = None) -> None:
         config = load_config(Path(path) if path else None)
     except ConfigError as exc:
         print(f"error: {exc}", file=sys.stderr)
-        raise SystemExit(1)
+        raise SystemExit(1) from exc
     editor = ConfigEditor(config)
     editor.run()
 

--- a/tests/e2e/test_config_precedence.py
+++ b/tests/e2e/test_config_precedence.py
@@ -2,10 +2,34 @@
 
 from __future__ import annotations
 
+import textwrap
 from pathlib import Path
-from typing import Mapping
+from typing import Any, Mapping, cast
+
+import pytest
 
 from noticiencias.config_manager import Config, load_config
+
+CONFIG_TOML = textwrap.dedent(
+    """
+    [app]
+    environment = "staging"
+
+    [collection]
+    async_enabled = true
+
+    [rate_limiting]
+    max_retries = 7
+    """
+).strip()
+
+ENV_FILE = textwrap.dedent(
+    """
+    NOTICIENCIAS__APP__ENVIRONMENT=production
+    NOTICIENCIAS__COLLECTION__ASYNC_ENABLED=false
+    NOTICIENCIAS__RATE_LIMITING__MAX_RETRIES=9
+    """
+).strip()
 
 
 def _load(
@@ -18,90 +42,72 @@ def _load(
     return load_config(path=config_path, environ=environ or {})
 
 
-def test_config_precedence_defaults(tmp_path: Path) -> None:
-    """Defaults should be used when no configuration layers are provided."""
-
-    config = _load(tmp_path / "config.toml")
-
-    assert config.app.environment == "development"
-    assert config.collection.async_enabled is False
-
-
-def test_config_precedence_config_file_overrides_defaults(tmp_path: Path) -> None:
-    """Values present in config.toml must override schema defaults."""
-
-    config_path = tmp_path / "config.toml"
-    config_path.write_text(
-        """
-[app]
-environment = "staging"
-
-[collection]
-async_enabled = true
-
-[database]
-driver = "postgresql"
-host = "db.internal"
-port = 6543
-user = "collector"
-password = "secret"
-""".strip()
-    )
-
-    config = _load(config_path)
-
-    assert config.app.environment == "staging"
-    assert config.collection.async_enabled is True
-    assert config.database.driver == "postgresql"
-    assert config.database.host == "db.internal"
-    assert config.database.port == 6543
-    assert config.database.user == "collector"
-
-
-def test_config_precedence_env_file_overrides_config_file(tmp_path: Path) -> None:
-    """.env entries should take precedence over TOML configuration values."""
+@pytest.mark.parametrize(
+    (
+        "with_config",
+        "with_env_file",
+        "process_env",
+        "expected_environment",
+        "expected_async",
+        "expected_retries",
+    ),
+    (
+        (False, False, {}, "development", False, 3),
+        (True, False, {}, "staging", True, 7),
+        (True, True, {}, "production", False, 9),
+        (
+            True,
+            True,
+            {"NOTICIENCIAS__APP__ENVIRONMENT": "test"},
+            "test",
+            False,
+            9,
+        ),
+    ),
+)
+def test_config_precedence_matrix(
+    tmp_path: Path,
+    with_config: bool,
+    with_env_file: bool,
+    process_env: Mapping[str, str],
+    expected_environment: str,
+    expected_async: bool,
+    expected_retries: int,
+) -> None:
+    """Validate precedence order defaults → config → .env → process env."""
 
     config_path = tmp_path / "config.toml"
-    config_path.write_text(
-        """
-[app]
-environment = "staging"
-
-[collection]
-async_enabled = true
-
-[rate_limiting]
-max_retries = 7
-""".strip()
-    )
     env_path = tmp_path / ".env"
-    env_path.write_text(
-        "\n".join(
-            [
-                "NOTICIENCIAS__APP__ENVIRONMENT=production",
-                "NOTICIENCIAS__COLLECTION__ASYNC_ENABLED=false",
-                "NOTICIENCIAS__RATE_LIMITING__MAX_RETRIES=9",
-            ]
-        )
-    )
 
-    config = _load(config_path)
+    if with_config:
+        config_path.write_text(CONFIG_TOML, encoding="utf-8")
+    if with_env_file:
+        env_path.write_text(ENV_FILE, encoding="utf-8")
+    else:
+        env_path.touch()
 
-    assert config.app.environment == "production"
-    assert config.collection.async_enabled is False
-    assert config.rate_limiting.max_retries == 9
+    config = _load(config_path, environ=process_env)
+
+    assert config.app.environment == expected_environment
+    assert config.collection.async_enabled is expected_async
+    assert config.rate_limiting.max_retries == expected_retries
 
 
-def test_config_precedence_process_env_overrides_env_file(tmp_path: Path) -> None:
-    """Process environment variables should override .env entries."""
+def test_config_precedence_metadata_tracks_layers(tmp_path: Path) -> None:
+    """The metadata should expose the precedence order for observability."""
 
     config_path = tmp_path / "config.toml"
-    config_path.write_text('[app]\nenvironment = "staging"\n')
+    config_path.write_text(CONFIG_TOML, encoding="utf-8")
     env_path = tmp_path / ".env"
-    env_path.write_text("NOTICIENCIAS__APP__ENVIRONMENT=production\n")
+    env_path.write_text(ENV_FILE, encoding="utf-8")
 
-    process_env = {"NOTICIENCIAS__APP__ENVIRONMENT": "test"}
+    config = load_config(
+        path=config_path,
+        environ={"NOTICIENCIAS__APP__ENVIRONMENT": "test"},
+    )
 
-    config = load_config(path=config_path, environ=process_env)
-
-    assert config.app.environment == "test"
+    metadata = cast(Any, config)._metadata
+    assert metadata.load_order == ("defaults", "file", "env-file", "env")
+    assert metadata.provenance["app.environment"].layer == "env"
+    assert metadata.provenance["collection.async_enabled"].layer == "env-file"
+    assert metadata.provenance["rate_limiting.max_retries"].layer == "env-file"


### PR DESCRIPTION
## Summary
- ensure explicit environment mappings take precedence over inherited process variables
- add end-to-end configuration precedence matrix coverage and metadata assertions
- document the precedence table in the README and fix GUI exit chaining for lint compliance

## Testing
- pytest -k precedence --no-cov
- ruff check
- mypy src noticiencias


------
https://chatgpt.com/codex/tasks/task_e_68e051fcac70832fb158996487de6b87