### PR TITLE
Add CLI runner end-to-end coverage

### DIFF
--- a/tests/e2e/test_runner_cli.py
+++ b/tests/e2e/test_runner_cli.py
@@ -1,202 +1,207 @@
-"""End-to-end style tests for the run_collector CLI entry point."""
+"""End-to-end style tests for the ``run_collector`` CLI entry point."""
 
 from __future__ import annotations
 
 import sys
+from dataclasses import dataclass, field
 from types import SimpleNamespace
-from typing import Sequence
-from unittest.mock import Mock
+from typing import Any, Dict, List, Optional
 
 import pytest
 
 import run_collector
 
 
-@pytest.fixture(autouse=True)
-def _reset_log_level(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Ensure LOG_LEVEL is unset between tests."""
-    monkeypatch.delenv("LOG_LEVEL", raising=False)
+def _build_results_summary() -> Dict[str, Any]:
+    """Return a minimal successful result payload for the fake system."""
 
-
-@pytest.fixture
-def cli_env(monkeypatch: pytest.MonkeyPatch) -> SimpleNamespace:
-    """Prepare a predictable environment for CLI tests."""
-
-    collection_result = {
+    return {
         "summary": {
-            "sources_processed": 2,
-            "articles_found": 4,
-            "articles_saved": 3,
-            "articles_scored": 3,
-            "final_selection_count": 2,
+            "sources_processed": 1,
+            "articles_found": 3,
+            "articles_saved": 2,
+            "articles_scored": 2,
+            "final_selection_count": 1,
         },
         "performance_metrics": {
             "total_duration_seconds": 1.0,
             "success_rate_percent": 100.0,
-            "articles_per_second": 4.0,
+            "articles_per_second": 3.0,
         },
-        "session_info": {"session_id": "session-123"},
     }
 
-    stub_system = SimpleNamespace(
-        initialize=Mock(return_value=True),
-        run_collection_cycle=Mock(return_value=collection_result),
-        get_top_articles=Mock(return_value=[]),
-    )
 
-    logger = Mock()
-    logger.info = Mock()
+@dataclass
+class StructuredLogger:
+    """Collect structured log payloads for assertions."""
 
-    logger_factory = Mock()
-    logger_factory.create_module_logger.return_value = logger
+    events: List[Dict[str, Any]] = field(default_factory=list)
 
-    check_dependencies = Mock(return_value=True)
+    def info(self, payload: Dict[str, Any]) -> None:
+        self.events.append({"level": "info", "payload": payload})
+
+    def error(self, payload: Dict[str, Any]) -> None:
+        self.events.append({"level": "error", "payload": payload})
+
+
+@dataclass
+class LoggerFactory:
+    """Return :class:`StructuredLogger` instances that share the same store."""
+
+    events: List[Dict[str, Any]] = field(default_factory=list)
+
+    def create_module_logger(self, _: str) -> StructuredLogger:
+        return StructuredLogger(self.events)
+
+
+@dataclass
+class FakeSystem:
+    """Minimal implementation of the collector system used by the CLI."""
+
+    initialize_result: bool = True
+    raise_on_run: bool = False
+    run_result: Dict[str, Any] = field(default_factory=_build_results_summary)
+    run_kwargs: Dict[str, Any] = field(default_factory=dict)
+
+    def initialize(self) -> bool:
+        return self.initialize_result
+
+    def run_collection_cycle(
+        self,
+        *,
+        sources_filter: Optional[List[str]],
+        dry_run: bool,
+        trace_id: str,
+    ) -> Dict[str, Any]:
+        if self.raise_on_run:
+            raise RuntimeError("collection failed")
+        self.run_kwargs = {
+            "sources_filter": sources_filter,
+            "dry_run": dry_run,
+            "trace_id": trace_id,
+        }
+        return self.run_result
+
+    @staticmethod
+    def get_top_articles(_: int) -> List[Dict[str, Any]]:
+        return []
+
+
+@pytest.fixture(autouse=True)
+def stub_sources(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Provide a lightweight catalog for CLI flows."""
 
     monkeypatch.setattr(
         run_collector,
         "ALL_SOURCES",
         {
-            "valid_source": {
-                "category": "astronomy",
-                "name": "Valid Source",
+            "alpha": {
+                "category": "science",
+                "name": "Alpha Source",
                 "credibility_score": 0.8,
             },
-            "secondary_source": {
-                "category": "astronomy",
-                "name": "Secondary Source",
-                "credibility_score": 0.6,
+            "beta": {
+                "category": "technology",
+                "name": "Beta Source",
+                "credibility_score": 0.7,
             },
         },
     )
-    monkeypatch.setattr(run_collector, "create_system", Mock(return_value=stub_system))
-    monkeypatch.setattr(
-        run_collector, "setup_logging", Mock(return_value=logger_factory)
-    )
-    monkeypatch.setattr(run_collector, "check_dependencies", check_dependencies)
-
-    return SimpleNamespace(
-        stub_system=stub_system,
-        logger=logger,
-        logger_factory=logger_factory,
-        check_dependencies=check_dependencies,
-    )
 
 
-def _invoke_cli(monkeypatch: pytest.MonkeyPatch, args: Sequence[str]) -> int:
-    """Execute the CLI entry point and capture its exit code."""
+@pytest.fixture
+def logger_factory(monkeypatch: pytest.MonkeyPatch) -> LoggerFactory:
+    """Patch ``setup_logging`` so tests can inspect structured payloads."""
 
-    monkeypatch.setattr(sys, "argv", ["run_collector.py", *args])
+    factory = LoggerFactory()
+    monkeypatch.setattr(run_collector, "setup_logging", lambda: factory)
+    return factory
+
+
+@pytest.fixture
+def stub_dependencies(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure dependency checks always pass during CLI invocations."""
+
+    monkeypatch.setattr(run_collector, "check_dependencies", lambda: True)
+
+
+def _invoke_cli(monkeypatch: pytest.MonkeyPatch, argv: List[str]) -> SystemExit:
+    """Execute ``run_collector.main`` with the provided arguments."""
+
+    monkeypatch.setattr(sys, "argv", ["run_collector.py", *argv])
     with pytest.raises(SystemExit) as exc_info:
         run_collector.main()
-    return int(exc_info.value.code)
+    return exc_info.value
 
 
-def test_cli_dry_run_success(
-    cli_env: SimpleNamespace,
-    monkeypatch: pytest.MonkeyPatch,
-    capsys: pytest.CaptureFixture[str],
-) -> None:
-    """The CLI should complete in dry-run mode and surface simulation messaging."""
+def test_cli_dry_run_invokes_collection(monkeypatch: pytest.MonkeyPatch, logger_factory: LoggerFactory, stub_dependencies: None, capsys: pytest.CaptureFixture[str]) -> None:
+    """``--dry-run`` should forward the flag and report simulation mode."""
 
-    exit_code = _invoke_cli(monkeypatch, ["--dry-run", "--show-articles", "0"])
+    system = FakeSystem()
+    monkeypatch.setattr(run_collector, "create_system", lambda: system)
+
+    exit_code = _invoke_cli(monkeypatch, ["--dry-run", "--show-articles", "0"]).code
 
     captured = capsys.readouterr().out
-
-    assert exit_code == 0
     assert "🧪 MODO SIMULACIÓN" in captured
-    assert "🌐 Procesando todas" in captured
+    assert exit_code == 0
+    assert system.run_kwargs["dry_run"] is True
+    assert system.run_kwargs["sources_filter"] is None
+    assert isinstance(system.run_kwargs["trace_id"], str)
+    assert any(event["payload"]["event"] == "cli.collection.completed" for event in logger_factory.events)
 
-    cli_env.stub_system.run_collection_cycle.assert_called_once()
-    call_kwargs = cli_env.stub_system.run_collection_cycle.call_args.kwargs
-    assert call_kwargs["dry_run"] is True
-    assert call_kwargs["sources_filter"] is None
 
+def test_cli_filters_sources(monkeypatch: pytest.MonkeyPatch, logger_factory: LoggerFactory, stub_dependencies: None, capsys: pytest.CaptureFixture[str]) -> None:
+    """Invalid sources should be reported while valid ones are processed."""
 
-def test_cli_sources_filter_and_validation(
-    cli_env: SimpleNamespace,
-    monkeypatch: pytest.MonkeyPatch,
-    capsys: pytest.CaptureFixture[str],
-) -> None:
-    """The CLI should filter requested sources and warn about invalid entries."""
+    system = FakeSystem()
+    monkeypatch.setattr(run_collector, "create_system", lambda: system)
 
     exit_code = _invoke_cli(
         monkeypatch,
-        ["--sources", "valid_source", "missing_source", "--show-articles", "0"],
+        ["--sources", "alpha", "missing", "--show-articles", "0"],
+    ).code
+
+    captured = capsys.readouterr().out
+    assert exit_code == 0
+    assert "⚠️  Fuentes no encontradas: missing" in captured
+    assert system.run_kwargs["sources_filter"] == ["alpha"]
+    assert any(
+        event["payload"].get("event") == "cli.sources.invalid"
+        for event in logger_factory.events
     )
 
+
+def test_cli_list_sources(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    """``--list-sources`` should print the catalog and exit early."""
+
+    exit_code = _invoke_cli(monkeypatch, ["--list-sources"]).code
     captured = capsys.readouterr().out
-
-    assert exit_code == 0
-    assert "⚠️  Fuentes no encontradas: missing_source" in captured
-    assert "Procesando 1 fuentes específicas: valid_source" in captured
-
-    cli_env.stub_system.run_collection_cycle.assert_called_once()
-    call_kwargs = cli_env.stub_system.run_collection_cycle.call_args.kwargs
-    assert call_kwargs["sources_filter"] == ["valid_source", "missing_source"]
-    assert call_kwargs["dry_run"] is False
-
-
-def test_cli_list_sources(
-    cli_env: SimpleNamespace,
-    monkeypatch: pytest.MonkeyPatch,
-    capsys: pytest.CaptureFixture[str],
-) -> None:
-    """Listing sources should print catalog information and exit cleanly."""
-
-    exit_code = _invoke_cli(monkeypatch, ["--list-sources"])
-
-    captured = capsys.readouterr().out
-
     assert exit_code == 0
     assert "📚 FUENTES DISPONIBLES" in captured
-    assert "Valid Source" in captured
-
-    # No system interactions should occur during listing
-    cli_env.stub_system.initialize.assert_not_called()
-    cli_env.stub_system.run_collection_cycle.assert_not_called()
 
 
-def test_cli_check_dependencies(
-    cli_env: SimpleNamespace,
-    monkeypatch: pytest.MonkeyPatch,
-    capsys: pytest.CaptureFixture[str],
-) -> None:
-    """Dependency checks should invoke the helper and exit successfully."""
+def test_cli_check_deps(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    """``--check-deps`` should invoke the helper and exit successfully."""
 
-    exit_code = _invoke_cli(monkeypatch, ["--check-deps"])
-
+    monkeypatch.setattr(run_collector, "check_dependencies", lambda: True)
+    exit_code = _invoke_cli(monkeypatch, ["--check-deps"]).code
     captured = capsys.readouterr().out
-
     assert exit_code == 0
     assert "✅ Todas las dependencias están instaladas" in captured
-    cli_env.check_dependencies.assert_called_once()
 
 
-@pytest.mark.parametrize(
-    "healthcheck_result, expected_exit",
-    [
-        (True, 0),
-        (False, 1),
-    ],
-)
-def test_cli_healthcheck_exit_codes(
-    cli_env: SimpleNamespace,
-    monkeypatch: pytest.MonkeyPatch,
-    healthcheck_result: bool,
-    expected_exit: int,
-) -> None:
-    """The healthcheck flag should propagate results and exit accordingly."""
+def test_cli_healthcheck_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Healthcheck success should exit zero and forward thresholds."""
 
-    received_kwargs = {}
+    captured_kwargs: Dict[str, Any] = {}
 
-    def _stub_run_cli(
-        *, max_pending: int | None, max_ingest_lag_minutes: int | None
-    ) -> bool:
-        received_kwargs["max_pending"] = max_pending
-        received_kwargs["max_ingest_lag_minutes"] = max_ingest_lag_minutes
-        return healthcheck_result
+    def stub_run_cli(**kwargs: Any) -> bool:
+        captured_kwargs.update(kwargs)
+        return True
 
-    monkeypatch.setattr("scripts.healthcheck.run_cli", _stub_run_cli)
+    module = SimpleNamespace(run_cli=stub_run_cli)
+    monkeypatch.setitem(sys.modules, "scripts.healthcheck", module)
 
     exit_code = _invoke_cli(
         monkeypatch,
@@ -207,7 +212,70 @@ def test_cli_healthcheck_exit_codes(
             "--healthcheck-max-ingest-minutes",
             "10",
         ],
+    ).code
+
+    assert exit_code == 0
+    assert captured_kwargs == {"max_pending": 25, "max_ingest_lag_minutes": 10}
+
+
+def test_cli_healthcheck_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Healthcheck failure should produce a non-zero exit code."""
+
+    module = SimpleNamespace(run_cli=lambda **_: False)
+    monkeypatch.setitem(sys.modules, "scripts.healthcheck", module)
+
+    exit_code = _invoke_cli(
+        monkeypatch,
+        [
+            "--healthcheck",
+            "--healthcheck-max-pending",
+            "99",
+        ],
+    ).code
+
+    assert exit_code == 1
+
+
+def test_cli_initialize_failure_logs_error(
+    monkeypatch: pytest.MonkeyPatch,
+    logger_factory: LoggerFactory,
+    stub_dependencies: None,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Failed system initialization should emit a structured error log."""
+
+    system = FakeSystem(initialize_result=False)
+    monkeypatch.setattr(run_collector, "create_system", lambda: system)
+
+    exit_code = _invoke_cli(monkeypatch, ["--show-articles", "0"]).code
+
+    captured = capsys.readouterr().out
+    assert exit_code == 1
+    assert "❌ Error durante inicialización del sistema" in captured
+    assert any(
+        event["payload"].get("event") == "cli.initialize.failed"
+        for event in logger_factory.events
     )
 
-    assert exit_code == expected_exit
-    assert received_kwargs == {"max_pending": 25, "max_ingest_lag_minutes": 10}
+
+def test_cli_collection_exception_logs_error(
+    monkeypatch: pytest.MonkeyPatch,
+    logger_factory: LoggerFactory,
+    stub_dependencies: None,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Unexpected exceptions should be surfaced via structured logging."""
+
+    system = FakeSystem(raise_on_run=True)
+    monkeypatch.setattr(run_collector, "create_system", lambda: system)
+
+    exit_code = _invoke_cli(monkeypatch, ["--show-articles", "0"]).code
+
+    captured = capsys.readouterr().out
+    assert exit_code == 1
+    assert "❌ Error durante ejecución: collection failed" in captured
+    assert any(
+        event["payload"].get("event") == "cli.collection.error"
+        for event in logger_factory.events
+    )
+


### PR DESCRIPTION
## Summary
- add structured error logging and source filtering to the CLI runner
- add end-to-end CLI tests covering major flags and error paths

## Testing
- pytest --no-cov tests/e2e/test_runner_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68e0563dbb34832f82254b44b45077ac