### PR TITLE
Ensure GUI config validation surfaces CLI-aligned errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,12 @@ Otros subcomandos disponibles: `--dump-defaults`, `--print-schema`, `--set clave
 - **CLI**: `python -m noticiencias.config_manager` (ver ejemplos anteriores). Se puede automatizar con `make config-set KEY=app.environment=production`.
 - **Editor GUI** (Tkinter): `python -m noticiencias.gui_config [ruta_config]`. En entornos sin pantalla usar `xvfb-run -a python -m noticiencias.gui_config`. Tras guardar cambios desde la GUI, valida el resultado con `python -m noticiencias.config_manager --config ruta/config.toml --explain clave` para confirmar que el CLI lee los valores persistidos.
 
+#### Validación cruzada GUI ↔ CLI
+1. Abre el editor con `python -m noticiencias.gui_config ./config.toml` y realiza los cambios necesarios.
+2. Al presionar **Save**, la GUI valida los tipos usando el mismo esquema Pydantic que el CLI. Cualquier valor inválido mostrará un mensaje explícito (`Configuration validation failed …`) sin escribir en disco.
+3. Para confirmar la persistencia, ejecuta `python -m noticiencias.config_manager --config ./config.toml --explain <clave>` y revisa tanto el valor como la fuente (`source: file (…/config.toml)`).
+4. Documenta el cambio en tu runbook/PR adjuntando la salida del comando anterior para mantener trazabilidad.
+
 ## Uso
 ### Recolección básica
 ```bash

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -20,6 +20,15 @@ Cuando la tubería falla, comienza con estos síntomas comunes antes de escalar 
   - Ajusta `domain_overrides` en `[rate_limiting]` (`config.toml`) o los parámetros de la fuente en `config/sources.py`, y reinicia el collector para aplicar los cambios.
   - Repite la ejecución con `python run_collector.py --dry-run --sources <id>` y verifica que el Runbook no reporte nuevas alertas.
 
+## Error: "Configuration validation failed" al guardar desde la GUI
+- **Contexto típico**: valores numéricos o estructuras inválidas capturados por el validador de `noticiencias.config_schema` al presionar **Save**.
+- **Diagnóstico rápido**:
+  - El cuadro de diálogo indica la clave específica (`database.connect_timeout`, etc.).
+  - Ejecuta `python -m noticiencias.config_manager --config ./config.toml --validate` para obtener el detalle completo en consola, incluyendo la capa que originó el valor.
+- **Resolución**:
+  - Corrige el valor en la GUI (asegurando tipos positivos para enteros y JSON válido para listas/tablas) y vuelve a guardar.
+  - Confirma el cambio con `python -m noticiencias.config_manager --config ./config.toml --explain <clave>`; la salida debe mostrar `source: file (.../config.toml)` con el nuevo valor.
+
 ## Error: `ModuleNotFoundError` para modelos de enriquecimiento
 - **Contexto típico**: entorno virtual sin dependencias opcionales o modelos locales eliminados.
 - **Diagnóstico rápido**:


### PR DESCRIPTION
## Summary
- stub Tkinter runtime to exercise ConfigEditor save/reload flows and add an invalid input regression test
- have the GUI surface Pydantic validation errors using the same formatting as the CLI and store the message in the status bar
- document the GUI↔CLI validation workflow and troubleshooting guidance for configuration edits

## Testing
- pytest --no-cov tests/gui/test_gui_config_persistence.py
- ruff check noticiencias tests
- mypy noticiencias
- bandit -ll -r noticiencias tests
- gitleaks detect --no-banner --redact
- pip-audit


------
https://chatgpt.com/codex/tasks/task_e_68e05dd671a4832f83994ef3674373ec