### PR TITLE
Improve CI workflows and add inventory automation

### DIFF
--- a/.github/workflows/audit-inventory-weekly.yml
+++ b/.github/workflows/audit-inventory-weekly.yml
@@ -1,0 +1,126 @@
+name: audit inventory weekly
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: audit-inventory-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  inventory:
+    name: inventory drift audit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Python
+        id: setup-python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Generate inventory snapshot
+        run: |
+          python scripts/generate_inventory.py \
+            --output reports/audit/00_inventory.generated.json \
+            --sample-size 10 \
+            --compare-to audit/00_inventory.json \
+            --diff-output reports/audit/00_inventory.diff \
+            --summary-output reports/audit/00_inventory.summary.json
+
+      - name: Capture drift metrics
+        id: summary
+        run: |
+          python - <<'PY'
+import json
+import os
+from pathlib import Path
+
+summary_path = Path('reports/audit/00_inventory.summary.json')
+summary = {"drift_count": 0, "changed_paths": []}
+if summary_path.exists():
+    summary = json.loads(summary_path.read_text(encoding='utf-8'))
+output_path = Path(os.environ['GITHUB_OUTPUT'])
+output_path.write_text(
+    f"drift_count={summary['drift_count']}\nchanged_paths={'|'.join(summary['changed_paths'])}\n",
+    encoding='utf-8',
+)
+PY
+
+      - name: Upload inventory artifacts
+        if: steps.summary.outputs.drift_count != '0'
+        uses: actions/upload-artifact@v4
+        with:
+          name: audit-inventory-drift
+          path: |
+            reports/audit/00_inventory.generated.json
+            reports/audit/00_inventory.diff
+            reports/audit/00_inventory.summary.json
+
+      - name: Open drift issue
+        if: steps.summary.outputs.drift_count != '0'
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const summary = JSON.parse(fs.readFileSync('reports/audit/00_inventory.summary.json', 'utf8'));
+            let diff = '';
+            try {
+              diff = fs.readFileSync('reports/audit/00_inventory.diff', 'utf8');
+            } catch (error) {
+              diff = '';
+            }
+            const title = 'Inventory drift detected';
+            const query = `repo:${context.repo.owner}/${context.repo.repo} is:issue is:open "${title}"`;
+            const search = await github.rest.search.issuesAndPullRequests({ q: query });
+            const bodyLines = [];
+            bodyLines.push('### Drift summary');
+            bodyLines.push(`- Drift count: ${summary.drift_count}`);
+            if (summary.changed_paths && summary.changed_paths.length > 0) {
+              bodyLines.push('- Changed paths:');
+              for (const path of summary.changed_paths) {
+                bodyLines.push(`  - \`${path}\``);
+              }
+            } else {
+              bodyLines.push('- Changed paths: _(not detected)_');
+            }
+            if (diff.trim()) {
+              const diffLines = diff.split('\n');
+              const previewLines = diffLines.slice(0, 200);
+              bodyLines.push('\n<details><summary>Diff preview</summary>');
+              bodyLines.push('');
+              bodyLines.push('```diff');
+              bodyLines.push(previewLines.join('\n'));
+              bodyLines.push('```');
+              if (diffLines.length > 200) {
+                bodyLines.push('\n_Diff truncated; download the attached artifact for the complete snapshot._');
+              }
+              bodyLines.push('</details>');
+            }
+            bodyLines.push('\nArtifacts: see the `audit-inventory-drift` attachment on this run.');
+            const body = bodyLines.join('\n');
+            if (search.data.total_count > 0) {
+              const issue = search.data.items[0];
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+              });
+            }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,77 +14,70 @@ permissions:
   contents: read
 
 jobs:
-  setup:
-    name: Setup
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-      - name: Set up Python
-        id: python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.12"
-          cache: "pip"
-          cache-dependency-path: |
-            requirements.lock
-            requirements-security.lock
-      - name: Bootstrap environment
-        run: make bootstrap
 
   lint:
     name: Lint
-    needs: setup
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v5
       - name: Set up Python
+        id: setup-python
         uses: actions/setup-python@v6
         with:
           python-version: "3.12"
-          cache: "pip"
-          cache-dependency-path: |
-            requirements.lock
-            requirements-security.lock
+      - name: Restore virtualenv cache
+        id: cache-venv
+        uses: actions/cache@v4
+        with:
+          path: .venv
+          key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('requirements.lock', 'requirements-security.lock') }}
+      - name: Bootstrap (idempotent)
+        run: make bootstrap
       - name: Lint
         run: make lint
 
   type:
     name: Type check
-    needs: setup
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v5
       - name: Set up Python
+        id: setup-python
         uses: actions/setup-python@v6
         with:
           python-version: "3.12"
-          cache: "pip"
-          cache-dependency-path: |
-            requirements.lock
-            requirements-security.lock
+      - name: Restore virtualenv cache
+        id: cache-venv
+        uses: actions/cache@v4
+        with:
+          path: .venv
+          key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('requirements.lock', 'requirements-security.lock') }}
+      - name: Bootstrap (idempotent)
+        run: make bootstrap
       - name: Type check
         run: make type
 
   config:
     name: Config validation
-    needs: setup
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v5
       - name: Set up Python
+        id: setup-python
         uses: actions/setup-python@v6
         with:
           python-version: "3.12"
-          cache: "pip"
-          cache-dependency-path: |
-            requirements.lock
-            requirements-security.lock
+      - name: Restore virtualenv cache
+        id: cache-venv
+        uses: actions/cache@v4
+        with:
+          path: .venv
+          key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('requirements.lock', 'requirements-security.lock') }}
+      - name: Bootstrap (idempotent)
+        run: make bootstrap
       - name: Validate configuration
         run: make config-validate
       - name: Regenerate field documentation
@@ -93,30 +86,30 @@ jobs:
         run: git diff --exit-code docs/config_fields.md
 
   test:
-    name: Test
-    needs: setup
+    name: test
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@v5
       - name: Set up Python
+        id: setup-python
         uses: actions/setup-python@v6
         with:
           python-version: "3.12"
-          cache: "pip"
-          cache-dependency-path: |
-            requirements.lock
-            requirements-security.lock
+      - name: Restore virtualenv cache
+        id: cache-venv
+        uses: actions/cache@v4
+        with:
+          path: .venv
+          key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('requirements.lock', 'requirements-security.lock') }}
+      - name: Bootstrap (idempotent)
+        run: make bootstrap
       - name: Run tests
-        run: make test
-      - name: Enforce coverage ratchet
-        env:
-          COVERAGE_XML: reports/coverage/coverage.xml
-          BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
-          REF="${BASE_REF:-origin/main}"
-          bash scripts/coverage_ratcheter.sh check --base-ref "$REF"
+          set -euo pipefail
+          mkdir -p reports/coverage
+          .venv/bin/pytest --cov-report=xml:reports/coverage/coverage.xml --cov-report=html:reports/coverage/html
       - name: Upload coverage report
         if: always()
         uses: actions/upload-artifact@v4
@@ -125,39 +118,70 @@ jobs:
           path: reports/coverage
           if-no-files-found: warn
 
+  coverage:
+    name: coverage
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+      - name: Download coverage artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-reports
+          path: reports/coverage
+      - name: Fetch base branch
+        if: github.event_name == 'pull_request'
+        run: git fetch --no-tags --depth=1 origin "${{ github.event.pull_request.base.ref }}"
+      - name: Verify coverage thresholds
+        env:
+          COVERAGE_XML: reports/coverage/coverage.xml
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          REF="${BASE_REF:-origin/main}"
+          bash scripts/coverage_ratcheter.sh check --base-ref "$REF"
+
   e2e:
     name: End-to-end
-    needs: setup
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v5
       - name: Set up Python
+        id: setup-python
         uses: actions/setup-python@v6
         with:
           python-version: "3.12"
-          cache: "pip"
-          cache-dependency-path: |
-            requirements.lock
-            requirements-security.lock
+      - name: Restore virtualenv cache
+        id: cache-venv
+        uses: actions/cache@v4
+        with:
+          path: .venv
+          key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('requirements.lock', 'requirements-security.lock') }}
+      - name: Bootstrap (idempotent)
+        run: make bootstrap
       - name: Run end-to-end suite
         run: make e2e
 
   perf:
     name: Performance
-    needs: setup
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v5
       - name: Set up Python
+        id: setup-python
         uses: actions/setup-python@v6
         with:
           python-version: "3.12"
-          cache: "pip"
-          cache-dependency-path: |
-            requirements.lock
-            requirements-security.lock
+      - name: Restore virtualenv cache
+        id: cache-venv
+        uses: actions/cache@v4
+        with:
+          path: .venv
+          key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('requirements.lock', 'requirements-security.lock') }}
+      - name: Bootstrap (idempotent)
+        run: make bootstrap
       - name: Run performance suite
         run: make perf
       - name: Upload performance reports
@@ -169,20 +193,22 @@ jobs:
           if-no-files-found: warn
 
   healthcheck:
-    name: Healthcheck
-    needs: setup
+    name: healthcheck
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v5
       - name: Set up Python
+        id: setup-python
         uses: actions/setup-python@v6
         with:
           python-version: "3.12"
-          cache: "pip"
-          cache-dependency-path: |
-            requirements.lock
-            requirements-security.lock
+      - name: Restore virtualenv cache
+        id: cache-venv
+        uses: actions/cache@v4
+        with:
+          path: .venv
+          key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('requirements.lock', 'requirements-security.lock') }}
       - name: Install dependencies
         run: make bootstrap
       - name: Run collector healthcheck
@@ -191,47 +217,134 @@ jobs:
             --healthcheck-max-pending 0 \
             --healthcheck-max-ingest-minutes 60
 
-  security:
-    name: Security
-    needs: setup
+  bandit:
+    name: bandit
     runs-on: ubuntu-latest
-    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@v5
       - name: Set up Python
+        id: setup-python
         uses: actions/setup-python@v6
         with:
           python-version: "3.12"
-          cache: "pip"
-          cache-dependency-path: |
-            requirements.lock
-            requirements-security.lock
-      - name: Run security scans
-        run: make audit
-      - name: Upload security reports
+      - name: Restore virtualenv cache
+        id: cache-venv
+        uses: actions/cache@v4
+        with:
+          path: .venv
+          key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('requirements.lock', 'requirements-security.lock') }}
+      - name: Install dependencies
+        run: make bootstrap
+      - name: Run Bandit
+        run: |
+          set -euo pipefail
+          mkdir -p reports/security
+          .venv/bin/bandit -ll -r src scripts -f json -o reports/security/bandit.json
+          .venv/bin/python scripts/security_gate.py bandit reports/security/bandit.json --severity HIGH
+      - name: Upload bandit report
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: security-reports
-          path: reports/security
+          name: bandit-report
+          path: reports/security/bandit.json
+          if-no-files-found: warn
+
+  gitleaks:
+    name: gitleaks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+      - name: Set up Python
+        id: setup-python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Restore virtualenv cache
+        id: cache-venv
+        uses: actions/cache@v4
+        with:
+          path: .venv
+          key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('requirements.lock', 'requirements-security.lock') }}
+      - name: Install dependencies
+        run: make bootstrap
+      - name: Install gitleaks
+        run: |
+          set -euo pipefail
+          GITLEAKS_VERSION="8.18.1"
+          curl -sSL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+            | tar -xz -C /usr/local/bin gitleaks
+      - name: Run gitleaks
+        run: |
+          set -euo pipefail
+          mkdir -p reports/security
+          gitleaks detect --redact --report-format json --report-path reports/security/gitleaks.json --config .gitleaks.toml
+          .venv/bin/python scripts/security_gate.py gitleaks reports/security/gitleaks.json --severity HIGH
+      - name: Upload gitleaks report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: gitleaks-report
+          path: reports/security/gitleaks.json
+          if-no-files-found: warn
+
+  pip-audit:
+    name: pip-audit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+      - name: Set up Python
+        id: setup-python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Restore virtualenv cache
+        id: cache-venv
+        uses: actions/cache@v4
+        with:
+          path: .venv
+          key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('requirements.lock', 'requirements-security.lock') }}
+      - name: Install dependencies
+        run: make bootstrap
+      - name: Run pip-audit
+        run: |
+          set -euo pipefail
+          mkdir -p reports/security
+          .venv/bin/pip-audit -r requirements.lock -f json -o reports/security/pip-audit-runtime.json --progress-spinner off
+          .venv/bin/python scripts/security_gate.py pip-audit reports/security/pip-audit-runtime.json --severity HIGH
+          .venv/bin/pip-audit -r requirements-security.lock -f json -o reports/security/pip-audit-security.json --progress-spinner off
+          .venv/bin/python scripts/security_gate.py pip-audit reports/security/pip-audit-security.json --severity HIGH
+      - name: Upload pip-audit reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pip-audit-reports
+          path: |
+            reports/security/pip-audit-runtime.json
+            reports/security/pip-audit-security.json
           if-no-files-found: warn
 
   audit-todos:
     name: Placeholder audit
-    needs: setup
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v5
       - name: Set up Python
+        id: setup-python
         uses: actions/setup-python@v6
         with:
           python-version: "3.12"
-          cache: "pip"
-          cache-dependency-path: |
-            requirements.lock
-            requirements-security.lock
+      - name: Restore virtualenv cache
+        id: cache-venv
+        uses: actions/cache@v4
+        with:
+          path: .venv
+          key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('requirements.lock', 'requirements-security.lock') }}
+      - name: Bootstrap (idempotent)
+        run: make bootstrap
       - name: Run placeholder audit
         run: make audit-todos-check
       - name: Upload placeholder reports
@@ -273,21 +386,32 @@ jobs:
     needs:
       - lint
       - type
-      - test
-      - security
+      - coverage
+      - bandit
+      - gitleaks
+      - pip-audit
+      - e2e
+      - perf
+      - healthcheck
+      - audit-todos
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@v5
       - name: Set up Python
+        id: setup-python
         uses: actions/setup-python@v6
         with:
           python-version: "3.12"
-          cache: "pip"
-          cache-dependency-path: |
-            requirements.lock
-            requirements-security.lock
+      - name: Restore virtualenv cache
+        id: cache-venv
+        uses: actions/cache@v4
+        with:
+          path: .venv
+          key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('requirements.lock', 'requirements-security.lock') }}
+      - name: Install dependencies
+        run: make bootstrap
       - name: Build wheel
         run: make build
       - name: Upload wheel artifact
@@ -324,14 +448,15 @@ jobs:
   update-ci-badge:
     name: Update CI badge
     needs:
-      - setup
       - lint
       - type
-      - test
+      - coverage
+      - bandit
+      - gitleaks
+      - pip-audit
       - e2e
       - perf
       - healthcheck
-      - security
       - audit-todos
       - build-artifacts
     if: ${{ github.event_name == 'push' && always() }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,18 +14,29 @@ on:
       - 'docs/**'
       - '.github/workflows/docs.yml'
 
+concurrency:
+  group: docs-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   linkcheck:
-    name: Markdown link check
+    name: docs/linkcheck
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        id: setup-python
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
+
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: docs-pip-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}
 
       - name: Install linkchecker
         run: |

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -8,6 +8,10 @@ on:
       - main
   workflow_dispatch:
 
+concurrency:
+  group: security-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   security-events: write

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -4,6 +4,7 @@ title = "Noticiencias Secret Scan"
 description = "Ignore known non-sensitive fixtures and generated assets."
 paths = [
   '''^tests/data/''',
+  '''^tests/test_security_gate.py$''',
   '''^docs/fixtures/''',
   '''^docs/examples/''',
   '''^reports/''',

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,0 +1,42 @@
+# Continuous Integration
+
+The CI system is designed to keep the feedback loop under 15 minutes while enforcing security and quality gates.
+
+## Required status checks
+
+| Name | Type | Default | Required | Description |
+| --- | --- | --- | --- | --- |
+| `test` | GitHub Actions job | PR & push | ✅ | Runs the unit suite under `pytest` with coverage reporting enabled. |
+| `coverage` | GitHub Actions job | PR & push | ✅ | Downloads coverage artifacts and enforces the ratchet via `scripts/coverage_ratcheter.sh`. |
+| `bandit` | GitHub Actions job | PR & push | ✅ | Executes Bandit with high-severity rules and blocks regressions through `scripts/security_gate.py`. |
+| `gitleaks` | GitHub Actions job | PR & push | ✅ | Scans the repository for committed secrets using the repo’s `.gitleaks.toml`. |
+| `pip-audit` | GitHub Actions job | PR & push | ✅ | Audits both runtime and security lock files for known vulnerabilities. |
+| `docs/linkcheck` | GitHub Actions job | PR & push (docs scope) | ✅ | Validates README and `docs/` hyperlinks with `linkchecker`. |
+| `healthcheck` | GitHub Actions job | PR & push | ✅ | Launches the collector health check (`run_collector.py --healthcheck`). |
+
+> These checks should be marked as “Required” in the branch protection rules for `main`.
+
+## Caching and concurrency
+
+- Every Python job restores the `.venv` directory from an `actions/cache` key derived from `requirements.lock` and `requirements-security.lock`. Bootstrap is still invoked, but it becomes a no-op for cache hits, cutting setup to seconds.
+- Workflows (`ci`, `docs`, `security`, and the weekly inventory audit) use `concurrency` blocks so that new pushes cancel superseded runs on the same ref.
+- Artifact-heavy jobs (`test`, `coverage`, `bandit`, `gitleaks`, `pip-audit`, and `build-artifacts`) upload reports that downstream tooling consumes.
+
+## Weekly inventory automation
+
+The `audit inventory weekly` workflow regenerates `audit/00_inventory.json` using `scripts/generate_inventory.py`. If the sanitized snapshot drifts from the committed baseline, the workflow:
+
+1. Uploads the generated JSON, diff, and summary as artifacts.
+2. Opens (or comments on) an “Inventory drift detected” issue that summarizes the changes.
+
+To run the same check locally:
+
+```bash
+python scripts/generate_inventory.py \
+  --output reports/audit/00_inventory.generated.json \
+  --compare-to audit/00_inventory.json \
+  --diff-output reports/audit/00_inventory.diff \
+  --summary-output reports/audit/00_inventory.summary.json
+```
+
+Review the diff and update `audit/00_inventory.json` when intentional changes occur.

--- a/scripts/generate_inventory.py
+++ b/scripts/generate_inventory.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""Generate and compare repository inventory snapshots."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import difflib
+import json
+import platform
+from collections import OrderedDict
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable, Iterator, List, Mapping, MutableMapping, Optional
+
+import tomllib
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+@dataclass(frozen=True)
+class InventoryOptions:
+    """Configuration for inventory generation."""
+
+    sample_size: int = 10
+    include_dirs: tuple[str, ...] = ("src", "scripts")
+
+
+def _list_top_level(root: Path) -> MutableMapping[str, Optional[List[str]]]:
+    inventory: "OrderedDict[str, Optional[List[str]]]" = OrderedDict()
+    for entry in sorted(root.iterdir(), key=lambda path: path.name):
+        if entry.name in {".git", "__pycache__", ".venv"}:
+            continue
+        if entry.is_dir():
+            children = [child.name for child in sorted(entry.iterdir(), key=lambda path: path.name)]
+            inventory[f"{entry.name}/"] = children
+        else:
+            inventory[entry.name] = None
+    return inventory
+
+
+def _collect_make_targets(makefile: Path) -> List[Mapping[str, str]]:
+    targets: List[Mapping[str, str]] = []
+    for line in makefile.read_text(encoding="utf-8").splitlines():
+        if "##" not in line:
+            continue
+        if line.strip().startswith("#"):
+            continue
+        lhs, _, description = line.partition("##")
+        target = lhs.split(":", 1)[0].strip()
+        description = description.strip()
+        if not target:
+            continue
+        targets.append({"target": target, "description": description})
+    return targets
+
+
+def _parse_requirements(path: Path) -> List[str]:
+    packages: List[str] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        packages.append(line.rstrip())
+    return packages
+
+
+def _optional_security(pyproject: Path) -> List[str]:
+    data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+    security = data.get("project", {}).get("optional-dependencies", {}).get("security", [])
+    return list(security)
+
+
+def _markdown_files(root: Path) -> List[str]:
+    files = sorted(
+        str(path.relative_to(root)).replace("\\", "/")
+        for path in root.rglob("*.md")
+        if ".venv" not in path.parts
+    )
+    return files
+
+
+def _python_modules(root: Path, options: InventoryOptions) -> Iterator[Path]:
+    for include in options.include_dirs:
+        base = root / include
+        if not base.exists():
+            continue
+        for path in sorted(base.rglob("*.py")):
+            if "__pycache__" in path.parts:
+                continue
+            yield path
+
+
+def _module_inventory(paths: Iterable[Path], sample_size: int, root: Path) -> Mapping[str, Mapping[str, List[str]]]:
+    sample: "OrderedDict[str, Mapping[str, List[str]]]" = OrderedDict()
+    for path in paths:
+        if len(sample) >= sample_size:
+            break
+        try:
+            module_ast = ast.parse(path.read_text(encoding="utf-8"))
+        except (SyntaxError, UnicodeDecodeError):
+            continue
+        functions: List[str] = []
+        classes: List[str] = []
+        for node in module_ast.body:
+            if isinstance(node, ast.FunctionDef):
+                functions.append(node.name)
+            elif isinstance(node, ast.ClassDef):
+                classes.append(node.name)
+        relative = str(path.relative_to(root)).replace("\\", "/")
+        sample[relative] = {"functions": functions, "classes": classes}
+    return sample
+
+
+def _open_questions(missing_file: Path) -> List[str]:
+    if not missing_file.exists():
+        return []
+    questions: List[str] = []
+    for line in missing_file.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if stripped.startswith("- Missing:"):
+            questions.append(stripped[2:].strip())
+    return questions
+
+
+def build_inventory(root: Path, options: InventoryOptions) -> Mapping[str, object]:
+    makefile = root / "Makefile"
+    requirements_txt = root / "requirements.txt"
+    pyproject = root / "pyproject.toml"
+    missing_md = root / "missing.md"
+
+    top_level = _list_top_level(root)
+    make_targets = _collect_make_targets(makefile) if makefile.exists() else []
+    requirements = _parse_requirements(requirements_txt) if requirements_txt.exists() else []
+    security_optional = _optional_security(pyproject) if pyproject.exists() else []
+    markdown_files = _markdown_files(root)
+    module_paths = _python_modules(root, options)
+    function_index = _module_inventory(module_paths, options.sample_size, root)
+    open_questions = _open_questions(missing_md)
+
+    entrypoints: MutableMapping[str, object] = OrderedDict()
+    main_module = "main.py"
+    entrypoints["main_module"] = main_module if (root / main_module).exists() else None
+    cli_path = Path("run_collector.py")
+    if cli_path.exists():
+        entrypoints["cli"] = {"path": cli_path.as_posix(), "help": f"python {cli_path.as_posix()} --help"}
+    entrypoints["make"] = "See make_targets section"
+
+    inventory: "OrderedDict[str, object]" = OrderedDict(
+        (
+            ("generated_at", datetime.now(timezone.utc).isoformat()),
+            ("python_version", platform.python_version()),
+            ("top_level_inventory", top_level),
+            ("entrypoints", entrypoints),
+            ("make_targets", make_targets),
+            (
+                "dependencies",
+                {
+                    "requirements_txt": requirements,
+                    "optional_security": security_optional,
+                },
+            ),
+            ("function_index_sample", function_index),
+            ("markdown_files", markdown_files),
+            ("open_questions", open_questions),
+        )
+    )
+    return inventory
+
+
+def _sanitize(payload: Mapping[str, object]) -> Mapping[str, object]:
+    sanitized = OrderedDict(payload)
+    sanitized.pop("generated_at", None)
+    sanitized.pop("python_version", None)
+    return sanitized
+
+
+def _diff_summary(previous: Mapping[str, object], current: Mapping[str, object]) -> tuple[int, List[str], str]:
+    before_dump = json.dumps(previous, indent=2, sort_keys=True, ensure_ascii=False).splitlines()
+    after_dump = json.dumps(current, indent=2, sort_keys=True, ensure_ascii=False).splitlines()
+    diff_lines = list(difflib.unified_diff(before_dump, after_dump, fromfile="baseline", tofile="current", lineterm=""))
+    relevant = [
+        line
+        for line in diff_lines
+        if line and not line.startswith(("+++", "---", "@@")) and line[0] in {"+", "-"}
+    ]
+
+    changed_paths = sorted(_diff_keys(previous, current))
+    return len(relevant), changed_paths, "\n".join(diff_lines)
+
+
+def _diff_keys(before: object, after: object, prefix: str | None = None) -> set[str]:
+    path_prefix = prefix or ""
+    if isinstance(before, Mapping) and isinstance(after, Mapping):
+        keys = set(before) | set(after)
+        changes: set[str] = set()
+        for key in keys:
+            next_prefix = f"{path_prefix}.{key}" if path_prefix else str(key)
+            if key not in before or key not in after:
+                changes.add(next_prefix)
+                continue
+            changes |= _diff_keys(before[key], after[key], next_prefix)
+        return changes
+    if isinstance(before, list) and isinstance(after, list):
+        return {path_prefix} if before != after else set()
+    return {path_prefix} if before != after else set()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate the repository inventory snapshot.")
+    parser.add_argument("--output", type=Path, default=ROOT / "audit" / "00_inventory.json", help="Path to write the inventory JSON.")
+    parser.add_argument("--sample-size", type=int, default=10, help="Number of modules to include in the function index sample.")
+    parser.add_argument("--compare-to", type=Path, help="Existing inventory JSON to compare against.")
+    parser.add_argument("--diff-output", type=Path, help="Optional file to store a unified diff between snapshots.")
+    parser.add_argument("--summary-output", type=Path, help="Optional file to store drift metadata as JSON.")
+    args = parser.parse_args()
+
+    options = InventoryOptions(sample_size=args.sample_size)
+    inventory = build_inventory(ROOT, options)
+
+    output_path: Path = args.output
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(inventory, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+    if args.compare_to and args.compare_to.exists():
+        previous = json.loads(args.compare_to.read_text(encoding="utf-8"))
+        drift_count, changed_paths, diff_text = _diff_summary(_sanitize(previous), _sanitize(inventory))
+        if args.diff_output:
+            diff_path = args.diff_output
+            diff_path.parent.mkdir(parents=True, exist_ok=True)
+            diff_path.write_text(diff_text + ("\n" if diff_text and not diff_text.endswith("\n") else ""), encoding="utf-8")
+        if args.summary_output:
+            summary_path = args.summary_output
+            summary_path.parent.mkdir(parents=True, exist_ok=True)
+            summary_path.write_text(
+                json.dumps({"drift_count": drift_count, "changed_paths": changed_paths}, indent=2, ensure_ascii=False) + "\n",
+                encoding="utf-8",
+            )
+        print(json.dumps({"drift_count": drift_count, "changed_paths": changed_paths}, ensure_ascii=False))
+    else:
+        print(json.dumps({"drift_count": 0, "changed_paths": []}, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add caching for Python jobs, split coverage ratchet into its own job, and break out Bandit/Gitleaks/pip-audit checks so they can be required individually
- add concurrency and caching to docs and security workflows plus extend the Gitleaks allowlist for test fixtures
- document the required status checks, add a weekly inventory drift workflow, and provide a generator script for audit snapshots

## Testing
- SKIP=end-of-file-fixer,trailing-whitespace,generate-api-docs make lint
- make type
- make test
- .venv/bin/bandit -ll -r src scripts -f json -o reports/security/bandit.json && .venv/bin/python scripts/security_gate.py bandit reports/security/bandit.json --severity HIGH
- gitleaks detect --redact --report-format json --report-path reports/security/gitleaks.json --config .gitleaks.toml && .venv/bin/python scripts/security_gate.py gitleaks reports/security/gitleaks.json --severity HIGH
- .venv/bin/pip-audit -r requirements.lock -f json -o reports/security/pip-audit-runtime.json --progress-spinner off && .venv/bin/python scripts/security_gate.py pip-audit reports/security/pip-audit-runtime.json --severity HIGH
- .venv/bin/pip-audit -r requirements-security.lock -f json -o reports/security/pip-audit-security.json --progress-spinner off && .venv/bin/python scripts/security_gate.py pip-audit reports/security/pip-audit-security.json --severity HIGH

------
https://chatgpt.com/codex/tasks/task_e_68e1172bdeb4832f8f8d4e67bb6e0de5